### PR TITLE
Auto trig like matter

### DIFF
--- a/triggering.go
+++ b/triggering.go
@@ -55,8 +55,7 @@ func (dsp *DataStreamProcessor) levelTriggerComputeAppend(records []*DataRecord)
 	nFoundTrigs := len(records)
 	nextFoundTrig := FrameIndex(math.MaxInt64)
 	if nFoundTrigs > 0 {
-		r := records[idxNextTrig]
-		nextFoundTrig = r.trigFrame - segment.firstFramenum
+		nextFoundTrig = records[idxNextTrig].trigFrame - segment.firstFramenum
 	}
 
 	// Normal loop through all samples in triggerable range

--- a/triggering.go
+++ b/triggering.go
@@ -55,7 +55,8 @@ func (dsp *DataStreamProcessor) levelTriggerComputeAppend(records []*DataRecord)
 	nFoundTrigs := len(records)
 	nextFoundTrig := FrameIndex(math.MaxInt64)
 	if nFoundTrigs > 0 {
-		nextFoundTrig = records[idxNextTrig].trigFrame - segment.firstFramenum
+		r := records[idxNextTrig]
+		nextFoundTrig = r.trigFrame - segment.firstFramenum
 	}
 
 	// Normal loop through all samples in triggerable range
@@ -102,8 +103,11 @@ func (dsp *DataStreamProcessor) autoTriggerComputeAppend(records []*DataRecord) 
 	idxNextTrig := 0
 	nFoundTrigs := len(records)
 	nextFoundTrig := FrameIndex(math.MaxInt64)
+	var nextFoundTrigLen int
 	if nFoundTrigs > 0 {
-		nextFoundTrig = records[idxNextTrig].trigFrame - segment.firstFramenum
+		r := records[idxNextTrig]
+		nextFoundTrig = r.trigFrame - segment.firstFramenum
+		nextFoundTrigLen = len(r.data)
 	}
 
 	// dsp.LastTrigger stores the frame of the last trigger found by the most recent invocation of TriggerData
@@ -122,10 +126,12 @@ func (dsp *DataStreamProcessor) autoTriggerComputeAppend(records []*DataRecord) 
 
 		} else {
 			// auto trigger not allowed
-			nextPotentialTrig = nextFoundTrig + delaySamples + FrameIndex(nsamp)
+			nextPotentialTrig = nextFoundTrig + delaySamples + FrameIndex(nextFoundTrigLen)
 			idxNextTrig++
 			if nFoundTrigs > idxNextTrig {
-				nextFoundTrig = records[idxNextTrig].trigFrame - segment.firstFramenum
+				r := records[idxNextTrig]
+				nextFoundTrig = r.trigFrame - segment.firstFramenum
+				nextFoundTrigLen = len(r.data)
 			} else {
 				nextFoundTrig = math.MaxInt64
 			}

--- a/triggering_test.go
+++ b/triggering_test.go
@@ -210,14 +210,31 @@ func TestSingles(t *testing.T) {
 
 	dsp.LevelTrigger = false
 	dsp.AutoTrigger = true
+	dsp.AutoDelay = 0 * time.Millisecond
+	testTriggerSubroutine(t, dsp, "Auto_0Millisecond", []FrameIndex{100, 1100, 2100, 3100, 4100, 5100, 6100, 7100, 8100})
+
+	dsp.LevelTrigger = false
+	dsp.AutoTrigger = true
 	dsp.AutoDelay = 500 * time.Millisecond
-	testTriggerSubroutine(t, dsp, "Auto", []FrameIndex{100, 5100})
+	// first trigger is a NPreSamples=100, ends at 1099
+	// next viable triger is 1100
+	// AutoDelay corresponds to 5000 samples, so we add that to 1100 to get 6100
+	testTriggerSubroutine(t, dsp, "Auto_500Millisecond", []FrameIndex{100, 6100})
 
 	dsp.LevelTrigger = true
-	testTriggerSubroutine(t, dsp, "Level+Auto", []FrameIndex{1000, 6000})
+	// AutoDelay corresponds to 5000 samples
+	// Level Trigger Occurs at 1000-1999
+	// Next Posible Trigger at 2000
+	// Delay 5000 to get 7000
+	testTriggerSubroutine(t, dsp, "Level+Auto_500Millisecond", []FrameIndex{1000, 7000})
 
 	dsp.AutoDelay = 200 * time.Millisecond
-	testTriggerSubroutine(t, dsp, "Level+Auto", []FrameIndex{1000, 3000, 5000, 7000, 9000})
+	// AutoDelay corresponds to 2000 samples
+	// Level Trigger Occurs at 1000-1999
+	// Next Posible Trigger at 2000
+	// Delay 2000 to get 4000
+	// Same Logic Takes 4000->7000
+	testTriggerSubroutine(t, dsp, "Level+Auto_200Millisecond", []FrameIndex{1000, 4000, 7000})
 }
 
 func testTriggerSubroutine(t *testing.T, dsp *DataStreamProcessor, trigname string, expectedFrames []FrameIndex) {

--- a/triggering_test.go
+++ b/triggering_test.go
@@ -298,12 +298,27 @@ func TestEdgeLevelInteraction(t *testing.T) {
 	dsp.LevelTrigger = true
 	dsp.LevelRising = true
 	dsp.LevelLevel = 100
-	testTriggerSubroutine(t, dsp, "Edge", []FrameIndex{1000})
+	// should yield a single edge trigger
+	testTriggerSubroutine(t, dsp, "Edge+Level 1", []FrameIndex{1000})
 	dsp.LevelLevel = 10000
-	testTriggerSubroutine(t, dsp, "Edge", []FrameIndex{1000})
+	// should yield a single edge trigger
+	testTriggerSubroutine(t, dsp, "Edge+Level 2", []FrameIndex{1000})
 	dsp.EdgeLevel = 20000
 	dsp.LevelLevel = 100
-	testTriggerSubroutine(t, dsp, "Level", []FrameIndex{1000})
+	// should yield a single level trigger
+	testTriggerSubroutine(t, dsp, "Edge + Level 3", []FrameIndex{1000})
+	dsp.EdgeLevel = 1
+	// should yield 2 edge triggers
+	testTriggerSubroutine(t, dsp, "Edge + Level 4", []FrameIndex{1000, 6000})
+	dsp.LevelLevel = 1
+	dsp.EdgeLevel = 20000
+	// should yield 2 level triggers
+	testTriggerSubroutine(t, dsp, "Edge + Level 5", []FrameIndex{1000, 6000})
+	dsp.LevelLevel = 1
+	dsp.EdgeTrigger = false
+	dsp.EdgeLevel = 1
+	// should yield 2 level triggers
+	testTriggerSubroutine(t, dsp, "Edge + Level 5", []FrameIndex{1000, 6000})
 }
 
 // TestEdgeVetosLevel tests that an edge trigger vetoes a level trigger as needed.


### PR DESCRIPTION
This makes auto_triggers more like matter by handling the case where `delaySamples` < `nsamp`. Before these changes that state would lead to overlapping records, or worse `delaySamples<=0` would hang. Also added a few tests to hit the `nFoundTrigs > idxNextTrig` branches.