### PR TITLE
Multi edge trigger

### DIFF
--- a/process_data.go
+++ b/process_data.go
@@ -11,15 +11,16 @@ import (
 
 // DataStreamProcessor contains all the state needed to decimate, trigger, write, and publish data.
 type DataStreamProcessor struct {
-	Channum     int
-	Publisher   chan<- []*DataRecord
-	Broker      *TriggerBroker
-	NSamples    int
-	NPresamples int
-	SampleRate  float64
-	LastTrigger FrameIndex
-	stream      DataStream
-	projectors  mat.Dense
+	Channum              int
+	Publisher            chan<- []*DataRecord
+	Broker               *TriggerBroker
+	NSamples             int
+	NPresamples          int
+	SampleRate           float64
+	LastTrigger          FrameIndex
+	LastEdgeMultiTrigger FrameIndex
+	stream               DataStream
+	projectors           mat.Dense
 	// realtime analysis is disable if projectors .IsZero
 	// otherwise projectors must be size (nbases,NSamples)
 	// such that projectors*data (data as a column vector) = modelCoefs
@@ -79,24 +80,6 @@ type DecimateState struct {
 	DecimateLevel   int
 	Decimate        bool
 	DecimateAvgMode bool
-}
-
-// TriggerState contains all the state that controls trigger logic
-type TriggerState struct {
-	AutoTrigger bool
-	AutoDelay   time.Duration
-
-	LevelTrigger bool
-	LevelRising  bool
-	LevelLevel   RawType
-
-	EdgeTrigger bool
-	EdgeRising  bool
-	EdgeFalling bool
-	EdgeLevel   int32
-
-	// TODO:  Noise info.
-	// TODO: group source/rx info.
 }
 
 // ConfigurePulseLengths sets this stream's pulse length and # of presamples.

--- a/process_data_test.go
+++ b/process_data_test.go
@@ -103,24 +103,22 @@ func TestAnalyzeRealtimeBases(t *testing.T) {
 	d = []RawType{1, 2, 3}
 	rec = &DataRecord{data: d, presamples: 1}
 	records = []*DataRecord{rec}
-	dsp.SetProjectorsBasis(*projectors3, *basis3)
+	dsp.RemoveProjectorsBasis()
 	dsp.AnalyzeData(records)
 	expect = RTExpect{
 		ResidualStdDev: 0,
-		ModelCoefs:     []float64{1, 2, 3},
+		ModelCoefs:     nil,
 		PTM:            1.0, Avg: 1.5, Max: 2.0, RMS: 1.5811388300841898}
 	testAnalyzeCheck(t, rec, expect, "Realtime C: 3 Bases, record truncated at end")
 
 	d = []RawType{1, 2, 3}
 	rec = &DataRecord{data: d, presamples: 0}
 	records = []*DataRecord{rec}
-	dsp.SetProjectorsBasis(*projectors3, *basis3)
+	dsp.RemoveProjectorsBasis()
 	dsp.AnalyzeData(records)
-	// residual should be [0,0,3]
-	// the uncorrected stdDeviation of this is sqrt(((0-1)^2+(0-1)^2+(3-1)^2)/3)
 	expect = RTExpect{
-		ResidualStdDev: 1.4142135623730951,
-		ModelCoefs:     []float64{0, 1, 2},
+		ResidualStdDev: 0,
+		ModelCoefs:     nil,
 		PTM:            math.NaN(), Avg: math.NaN(), Max: math.NaN(), RMS: math.NaN()}
 	testAnalyzeCheck(t, rec, expect, "Realtime D: 3 Bases, record truncated at front")
 

--- a/process_data_test.go
+++ b/process_data_test.go
@@ -30,221 +30,131 @@ func TestStdDev(t *testing.T) {
 // TestAnalyze tests the DataChannel.AnalyzeData computations on a very simple "pulse".
 func TestAnalyze(t *testing.T) {
 	d := []RawType{10, 10, 10, 10, 15, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10}
-	rec := &DataRecord{data: d}
+	rec := &DataRecord{data: d, presamples: 4}
 	records := []*DataRecord{rec}
 
 	dsp := &DataStreamProcessor{NPresamples: 4, NSamples: len(d)}
 	dsp.AnalyzeData(records)
 
-	expectPTM := 10.0
-	if rec.pretrigMean != expectPTM {
-		t.Errorf("Pretrigger mean = %f, want %f", rec.pretrigMean, expectPTM)
-		t.Logf("%v\n", rec)
-	}
+	expect := RTExpect{
+		ResidualStdDev: 0,
+		ModelCoefs:     nil,
+		PTM:            10.0, Avg: 5.0, Max: 10.0, RMS: 5.84522597225006}
+	testAnalyzeCheck(t, rec, expect, "Analyze A")
+}
 
-	expectAvg := 5.0
-	if rec.pulseAverage != expectAvg {
-		t.Errorf("Pulse average = %f, want %f", rec.pulseAverage, expectAvg)
-		t.Logf("%v\n", rec)
-	}
-
-	expectMax := 10.0
-	if rec.peakValue != expectMax {
-		t.Errorf("Peak value = %f, want %f", rec.peakValue, expectMax)
-		t.Logf("%v\n", rec)
-	}
-
-	expectRMS := 0.0
-	for i := 4; i < len(d); i++ {
-		diff := float64(d[i]) - expectPTM
-		expectRMS += diff * diff
-	}
-	expectRMS /= float64(len(d) - 4)
-	expectRMS = math.Sqrt(expectRMS)
-	if math.Abs(rec.pulseRMS-expectRMS) > 1e-8 {
-		t.Errorf("Pulse RMS = %f, want %f to 8 digits", rec.pulseRMS, expectRMS)
-		t.Logf("%v\n", rec)
-	}
-
-	// the realtime analysis did not run, so we should get the Zero value
-	expectResidualStdDev := 0.0
-	if rec.residualStdDev != expectResidualStdDev {
-		t.Errorf("ResidualStdDev mean = %f, want %f", rec.residualStdDev, expectResidualStdDev)
-		t.Logf("%v\n", rec)
-	}
-
-	// the realtime analysis did not run, so we should get the Zero value
-	if rec.modelCoefs != nil {
-		t.Log("rec.modelCoefs should have Zero Value, instead has", rec.modelCoefs)
-		t.Logf("%v\n", rec)
-		t.Fail()
-	}
+type RTExpect struct {
+	Max            float64
+	RMS            float64
+	Avg            float64
+	PTM            float64
+	ModelCoefs     []float64
+	ResidualStdDev float64
 }
 
 //TestAnalyzeRealtime tests the DataChannel.AnalyzeData computations on a very simple "pulse".
-func TestAnalyzeRealtimeBases3(t *testing.T) {
+func TestAnalyzeRealtimeBases(t *testing.T) {
 	d := []RawType{1, 2, 3, 4}
-	rec := &DataRecord{data: d}
+	rec := &DataRecord{data: d, presamples: 1}
 	records := []*DataRecord{rec}
 
 	dsp := &DataStreamProcessor{NPresamples: 1, NSamples: len(d)}
 
 	// assign the projectors and basis
 	nbases := 3
-	projectors := mat.NewDense(nbases, dsp.NSamples,
+	projectors3 := mat.NewDense(nbases, dsp.NSamples,
 		[]float64{1, 0, 0, 0,
 			0, 1, 0, 0,
 			0, 0, 1, 0})
-	basis := mat.NewDense(dsp.NSamples, nbases,
+	basis3 := mat.NewDense(dsp.NSamples, nbases,
 		[]float64{1, 0, 0,
 			0, 1, 0,
 			0, 0, 1,
 			0, 0, 0})
-	dsp.SetProjectorsBasis(*projectors, *basis)
+	dsp.SetProjectorsBasis(*projectors3, *basis3)
 	dsp.AnalyzeData(records)
-
-	if false {
-		t.Log("projectors")
-		matPrint(&dsp.projectors, t)
-		t.Log(dsp.projectors.Dims())
-		t.Log("basis")
-		matPrint(&dsp.basis, t)
-		t.Log(dsp.basis.Dims())
-		t.Log("modelCoefs", rec.modelCoefs)
-		t.Log("residualStd", rec.residualStdDev)
-	}
 
 	// residual should be [0,0,0,4]
 	// the uncorrected stdDeviation of this is sqrt(((0-1)^2+(0-1)^2+(0-1)^2+(4-1)^2)/4)
-	expectResidualStdDev := 1.7320508075688772
-	if rec.residualStdDev != expectResidualStdDev {
-		t.Errorf("ResidualStdDev mean = %f, want %f", rec.residualStdDev, expectResidualStdDev)
-		t.Logf("%v\n", rec)
-	}
-
-	expectModelCoefs := []float64{1, 2, 3}
-	modelCoefsCorrect := true
-	for i, v := range expectModelCoefs {
-		if v != rec.modelCoefs[i] {
-			modelCoefsCorrect = false
-		}
-	}
-
-	if !modelCoefsCorrect {
-		t.Log("rec.modelCoefs", rec.modelCoefs)
-		t.Log("should equal expectModelCoefs", expectModelCoefs)
-		t.Fail()
-	}
-
-	expectPTM := 1.0
-	if rec.pretrigMean != expectPTM {
-		t.Errorf("Pretrigger mean = %f, want %f", rec.pretrigMean, expectPTM)
-		t.Logf("%v\n", rec)
-	}
-
-	expectAvg := 2.0
-	if rec.pulseAverage != expectAvg {
-		t.Errorf("Pulse average = %f, want %f", rec.pulseAverage, expectAvg)
-		t.Logf("%v\n", rec)
-	}
-
-	expectMax := 3.0
-	if rec.peakValue != expectMax {
-		t.Errorf("Peak value = %f, want %f", rec.peakValue, expectMax)
-		t.Logf("%v\n", rec)
-	}
-
-	expectRMS := 0.0
-	for i := 4; i < len(d); i++ {
-		diff := float64(d[i]) - expectPTM
-		expectRMS += diff * diff
-	}
-	expectRMS /= float64(len(d) - 4)
-	expectRMS = math.Sqrt(expectRMS)
-	if math.Abs(rec.pulseRMS-expectRMS) > 1e-8 {
-		t.Errorf("Pulse RMS = %f, want %f to 8 digits", rec.pulseRMS, expectRMS)
-		t.Logf("%v\n", rec)
-	}
-}
-
-func TestAnalyzeRealtimeBases1(t *testing.T) {
-	d := []RawType{1, 2, 3, 4}
-	rec := &DataRecord{data: d}
-	records := []*DataRecord{rec}
-
-	dsp := &DataStreamProcessor{NPresamples: 1, NSamples: len(d)}
+	expect := RTExpect{
+		ResidualStdDev: 1.7320508075688772,
+		ModelCoefs:     []float64{1, 2, 3},
+		PTM:            1.0, Avg: 2.0, Max: 3.0, RMS: 2.1602468994692865}
+	testAnalyzeCheck(t, rec, expect, "Realtime A: 3 Bases, no Trunc")
 
 	// assign the projectors and basis
-	nbases := 1
-	projectors := mat.NewDense(nbases, dsp.NSamples,
+	nbases = 1
+	projectors1 := mat.NewDense(nbases, dsp.NSamples,
 		[]float64{1, 0, 0, 0})
-	basis := mat.NewDense(dsp.NSamples, nbases,
+	basis1 := mat.NewDense(dsp.NSamples, nbases,
 		[]float64{1,
 			0,
 			0,
 			0})
-	dsp.SetProjectorsBasis(*projectors, *basis)
+	dsp.SetProjectorsBasis(*projectors1, *basis1)
 	dsp.AnalyzeData(records)
-
-	if false {
-		t.Log("projectors")
-		matPrint(&dsp.projectors, t)
-		t.Log(dsp.projectors.Dims())
-		t.Log("basis")
-		matPrint(&dsp.basis, t)
-		t.Log(dsp.basis.Dims())
-		t.Log("modelCoefs", rec.modelCoefs)
-		t.Log("residualStd", rec.residualStdDev)
-	}
-
 	// residual should be [0,2,3,4]
-	expectResidualStdDev := 1.479019945774904
-	if rec.residualStdDev != expectResidualStdDev {
-		t.Errorf("ResidualStdDev = %f, want %f", rec.residualStdDev, expectResidualStdDev)
+	expect = RTExpect{
+		ResidualStdDev: 1.479019945774904,
+		ModelCoefs:     []float64{1},
+		PTM:            1.0, Avg: 2.0, Max: 3.0, RMS: 2.1602468994692865}
+	testAnalyzeCheck(t, rec, expect, "Realtime B: 1 Bases, no Trunc")
+
+	d = []RawType{1, 2, 3}
+	rec = &DataRecord{data: d, presamples: 1}
+	records = []*DataRecord{rec}
+	dsp.SetProjectorsBasis(*projectors3, *basis3)
+	dsp.AnalyzeData(records)
+	expect = RTExpect{
+		ResidualStdDev: 0,
+		ModelCoefs:     []float64{1, 2, 3},
+		PTM:            1.0, Avg: 1.5, Max: 2.0, RMS: 1.5811388300841898}
+	testAnalyzeCheck(t, rec, expect, "Realtime C: 3 Bases, record truncated at end")
+
+	d = []RawType{1, 2, 3}
+	rec = &DataRecord{data: d, presamples: 0}
+	records = []*DataRecord{rec}
+	dsp.SetProjectorsBasis(*projectors3, *basis3)
+	dsp.AnalyzeData(records)
+	// residual should be [0,0,3]
+	// the uncorrected stdDeviation of this is sqrt(((0-1)^2+(0-1)^2+(3-1)^2)/3)
+	expect = RTExpect{
+		ResidualStdDev: 1.4142135623730951,
+		ModelCoefs:     []float64{0, 1, 2},
+		PTM:            math.NaN(), Avg: math.NaN(), Max: math.NaN(), RMS: math.NaN()}
+	testAnalyzeCheck(t, rec, expect, "Realtime D: 3 Bases, record truncated at front")
+
+}
+
+func testAnalyzeCheck(t *testing.T, rec *DataRecord, expect RTExpect, name string) {
+	if rec.residualStdDev != expect.ResidualStdDev {
+		t.Errorf("%v: ResidualStdDev = %v, want %v", name, rec.residualStdDev, expect.ResidualStdDev)
 		t.Logf("%v\n", rec)
 	}
-
-	expectModelCoefs := []float64{1}
 	modelCoefsCorrect := true
-	for i, v := range expectModelCoefs {
-		if v != rec.modelCoefs[i] {
+	for i, v := range expect.ModelCoefs {
+		if i >= len(rec.modelCoefs) || v != rec.modelCoefs[i] {
 			modelCoefsCorrect = false
 		}
 	}
-
 	if !modelCoefsCorrect {
-		t.Log("rec.modelCoefs", rec.modelCoefs)
-		t.Log("should equal expectModelCoefs", expectModelCoefs)
-		t.Fail()
+		t.Log(name, "\nrec.modelCoefs", rec.modelCoefs)
+		t.Error("should equal expectModelCoefs", expect.ModelCoefs)
 	}
-
-	expectPTM := 1.0
-	if rec.pretrigMean != expectPTM {
-		t.Errorf("Pretrigger mean = %f, want %f", rec.pretrigMean, expectPTM)
+	if rec.pretrigMean != expect.PTM && !(math.IsNaN(rec.pretrigMean) && math.IsNaN(expect.PTM)) {
+		t.Errorf("Pretrigger mean = %v, want %v", rec.pretrigMean, expect.PTM)
 		t.Logf("%v\n", rec)
 	}
-
-	expectAvg := 2.0
-	if rec.pulseAverage != expectAvg {
-		t.Errorf("Pulse average = %f, want %f", rec.pulseAverage, expectAvg)
+	if rec.pulseAverage != expect.Avg && !(math.IsNaN(rec.pulseAverage) && math.IsNaN(expect.Avg)) {
+		t.Errorf("%v, Pulse average = %v, want %v", name, rec.pulseAverage, expect.Avg)
 		t.Logf("%v\n", rec)
 	}
-
-	expectMax := 3.0
-	if rec.peakValue != expectMax {
-		t.Errorf("Peak value = %f, want %f", rec.peakValue, expectMax)
+	if rec.peakValue != expect.Max && !(math.IsNaN(rec.peakValue) && math.IsNaN(expect.Max)) {
+		t.Errorf("%v, Peak value = %v, want %v", name, rec.peakValue, expect.Max)
 		t.Logf("%v\n", rec)
 	}
-
-	expectRMS := 0.0
-	for i := 4; i < len(d); i++ {
-		diff := float64(d[i]) - expectPTM
-		expectRMS += diff * diff
-	}
-	expectRMS /= float64(len(d) - 4)
-	expectRMS = math.Sqrt(expectRMS)
-	if math.Abs(rec.pulseRMS-expectRMS) > 1e-8 {
-		t.Errorf("Pulse RMS = %f, want %f to 8 digits", rec.pulseRMS, expectRMS)
+	if rec.pulseRMS != expect.RMS && !(math.IsNaN(rec.pulseRMS) && math.IsNaN(expect.RMS)) {
+		t.Errorf("%v, Pulse RMS = %v, want %v", name, rec.pulseRMS, expect.RMS)
 		t.Logf("%v\n", rec)
 	}
 }

--- a/triggering_test.go
+++ b/triggering_test.go
@@ -456,3 +456,17 @@ func BenchmarkLevelTrigger0TriggersOpsAreSamples(b *testing.B) {
 	}
 
 }
+
+func TestKinkModelResult(t *testing.T) {
+	xdata := []float64{0, 1, 2, 3, 4, 5, 6, 7}
+	ydata := []float64{0, 0, 0, 0, 1, 2, 3, 4}
+	ymodel, a, b, c, X2, err := kinkModelResult(3, xdata, ydata)
+	if a != 0 || b != 0 || c != 1 || X2 != 0 || err != nil {
+		t.Errorf("a %v, b %v, c %v, X2 %v, err %v, ymodel %v", a, b, c, X2, err, ymodel)
+	}
+	ymodel, a, b, c, X2, err = kinkModelResult(4, xdata, ydata)
+	if a != 0.6818181818181821 || b != 0.22727272727272738 ||
+		c != 1.1363636363636362 || X2 != 0.45454545454545453 || err != nil {
+		t.Errorf("a %v, b %v, c %v, X2 %v, err %v, ymodel %v", a, b, c, X2, err, ymodel)
+	}
+}

--- a/triggering_test.go
+++ b/triggering_test.go
@@ -193,48 +193,7 @@ func TestSingles(t *testing.T) {
 	go broker.Run()
 	defer broker.Stop()
 	dsp := NewDataStreamProcessor(0, publisher, broker)
-	dsp.NPresamples = 100
-	dsp.NSamples = 1000
-	dsp.SampleRate = 10000.0
 
-	dsp.EdgeTrigger = true
-	dsp.EdgeRising = true
-	dsp.EdgeLevel = 100
-	testTriggerSubroutine(t, dsp, "Edge", []FrameIndex{1000})
-
-	dsp.EdgeTrigger = false
-	dsp.LevelTrigger = true
-	dsp.LevelRising = true
-	dsp.LevelLevel = 100
-	testTriggerSubroutine(t, dsp, "Level", []FrameIndex{1000})
-
-	dsp.LevelTrigger = false
-	dsp.AutoTrigger = true
-	dsp.AutoDelay = 0 * time.Millisecond
-	// Zero Delay results in records that are spaced by 1000 samples (dsp.NSamples)
-	// starting at 100 (dsp.NPreSamples)
-	testTriggerSubroutine(t, dsp, "Auto_0Millisecond", []FrameIndex{100, 1100, 2100, 3100, 4100, 5100, 6100, 7100, 8100})
-
-	dsp.LevelTrigger = false
-	dsp.AutoTrigger = true
-	dsp.AutoDelay = 500 * time.Millisecond
-	// first trigger is at NPreSamples=100
-	// AutoDelay corresponds to 5000 samples, so we add that to 1100 to get 5100
-	testTriggerSubroutine(t, dsp, "Auto_500Millisecond", []FrameIndex{100, 5100})
-
-	dsp.LevelTrigger = true
-	testTriggerSubroutine(t, dsp, "Level+Auto_500Millisecond", []FrameIndex{1000, 6000})
-
-	dsp.LevelLevel = 1
-	dsp.AutoTrigger = false
-	testTriggerSubroutine(t, dsp, "Level_SmallThresh", []FrameIndex{1000, 6000})
-
-	dsp.AutoDelay = 200 * time.Millisecond
-	dsp.AutoTrigger = true
-	testTriggerSubroutine(t, dsp, "Level+Auto_200Millisecond", []FrameIndex{1000, 3000, 5000, 6000, 8000})
-}
-
-func testTriggerSubroutine(t *testing.T, dsp *DataStreamProcessor, trigname string, expectedFrames []FrameIndex) {
 	const bigval = 8000
 	const tframe = 1000
 	raw := make([]RawType, 10000)
@@ -246,6 +205,49 @@ func testTriggerSubroutine(t *testing.T, dsp *DataStreamProcessor, trigname stri
 	for i := tframe2; i < tframe2+10; i++ {
 		raw[i] = smallval
 	}
+
+	dsp.NPresamples = 100
+	dsp.NSamples = 1000
+	dsp.SampleRate = 10000.0
+
+	dsp.EdgeTrigger = true
+	dsp.EdgeRising = true
+	dsp.EdgeLevel = 100
+	testTriggerSubroutine(t, raw, dsp, "Edge", []FrameIndex{1000})
+
+	dsp.EdgeTrigger = false
+	dsp.LevelTrigger = true
+	dsp.LevelRising = true
+	dsp.LevelLevel = 100
+	testTriggerSubroutine(t, raw, dsp, "Level", []FrameIndex{1000})
+
+	dsp.LevelTrigger = false
+	dsp.AutoTrigger = true
+	dsp.AutoDelay = 0 * time.Millisecond
+	// Zero Delay results in records that are spaced by 1000 samples (dsp.NSamples)
+	// starting at 100 (dsp.NPreSamples)
+	testTriggerSubroutine(t, raw, dsp, "Auto_0Millisecond", []FrameIndex{100, 1100, 2100, 3100, 4100, 5100, 6100, 7100, 8100})
+
+	dsp.LevelTrigger = false
+	dsp.AutoTrigger = true
+	dsp.AutoDelay = 500 * time.Millisecond
+	// first trigger is at NPreSamples=100
+	// AutoDelay corresponds to 5000 samples, so we add that to 1100 to get 5100
+	testTriggerSubroutine(t, raw, dsp, "Auto_500Millisecond", []FrameIndex{100, 5100})
+
+	dsp.LevelTrigger = true
+	testTriggerSubroutine(t, raw, dsp, "Level+Auto_500Millisecond", []FrameIndex{1000, 6000})
+
+	dsp.LevelLevel = 1
+	dsp.AutoTrigger = false
+	testTriggerSubroutine(t, raw, dsp, "Level_SmallThresh", []FrameIndex{1000, 6000})
+
+	dsp.AutoDelay = 200 * time.Millisecond
+	dsp.AutoTrigger = true
+	testTriggerSubroutine(t, raw, dsp, "Level+Auto_200Millisecond", []FrameIndex{1000, 3000, 5000, 6000, 8000})
+}
+
+func testTriggerSubroutine(t *testing.T, raw []RawType, dsp *DataStreamProcessor, trigname string, expectedFrames []FrameIndex) ([]*DataRecord, []*DataRecord) {
 	dsp.LastTrigger = math.MinInt64 / 4 // far in the past, but not so far we can't subtract from it.
 	sampleTime := time.Duration(float64(time.Second) / dsp.SampleRate)
 	segment := NewDataSegment(raw, 1, 0, time.Now(), sampleTime)
@@ -265,7 +267,7 @@ func testTriggerSubroutine(t *testing.T, dsp *DataStreamProcessor, trigname stri
 
 	// Check the data samples for the first trigger
 	if len(primaries) == 0 {
-		return
+		return primaries, secondaries
 	}
 	pt := primaries[0]
 	offset := int(expectedFrames[0]) - dsp.NPresamples
@@ -277,6 +279,7 @@ func testTriggerSubroutine(t *testing.T, dsp *DataStreamProcessor, trigname stri
 		}
 	}
 	dsp.stream.TrimKeepingN(0)
+	return primaries, secondaries
 }
 
 // TestEdgeLevelInteraction tests that a single edge trigger happens where expected, even if
@@ -289,6 +292,17 @@ func TestEdgeLevelInteraction(t *testing.T) {
 	go broker.Run()
 	defer broker.Stop()
 	dsp := NewDataStreamProcessor(0, publisher, broker)
+	const bigval = 8000
+	const tframe = 1000
+	raw := make([]RawType, 10000)
+	for i := tframe; i < tframe+10; i++ {
+		raw[i] = bigval
+	}
+	const smallval = 1
+	const tframe2 = 6000
+	for i := tframe2; i < tframe2+10; i++ {
+		raw[i] = smallval
+	}
 	dsp.NPresamples = 100
 	dsp.NSamples = 1000
 
@@ -299,26 +313,96 @@ func TestEdgeLevelInteraction(t *testing.T) {
 	dsp.LevelRising = true
 	dsp.LevelLevel = 100
 	// should yield a single edge trigger
-	testTriggerSubroutine(t, dsp, "Edge+Level 1", []FrameIndex{1000})
+	testTriggerSubroutine(t, raw, dsp, "Edge+Level 1", []FrameIndex{1000})
 	dsp.LevelLevel = 10000
 	// should yield a single edge trigger
-	testTriggerSubroutine(t, dsp, "Edge+Level 2", []FrameIndex{1000})
+	testTriggerSubroutine(t, raw, dsp, "Edge+Level 2", []FrameIndex{1000})
 	dsp.EdgeLevel = 20000
 	dsp.LevelLevel = 100
 	// should yield a single level trigger
-	testTriggerSubroutine(t, dsp, "Edge + Level 3", []FrameIndex{1000})
+	testTriggerSubroutine(t, raw, dsp, "Edge + Level 3", []FrameIndex{1000})
 	dsp.EdgeLevel = 1
 	// should yield 2 edge triggers
-	testTriggerSubroutine(t, dsp, "Edge + Level 4", []FrameIndex{1000, 6000})
+	testTriggerSubroutine(t, raw, dsp, "Edge + Level 4", []FrameIndex{1000, 6000})
 	dsp.LevelLevel = 1
 	dsp.EdgeLevel = 20000
 	// should yield 2 level triggers
-	testTriggerSubroutine(t, dsp, "Edge + Level 5", []FrameIndex{1000, 6000})
+	testTriggerSubroutine(t, raw, dsp, "Edge + Level 5", []FrameIndex{1000, 6000})
 	dsp.LevelLevel = 1
 	dsp.EdgeTrigger = false
 	dsp.EdgeLevel = 1
 	// should yield 2 level triggers
-	testTriggerSubroutine(t, dsp, "Edge + Level 5", []FrameIndex{1000, 6000})
+	testTriggerSubroutine(t, raw, dsp, "Edge + Level 5", []FrameIndex{1000, 6000})
+}
+
+func TestEdgeMulti(t *testing.T) {
+	const nchan = 1
+
+	publisher := make(chan []*DataRecord)
+	broker := NewTriggerBroker(nchan)
+	go broker.Run()
+	defer broker.Stop()
+	dsp := NewDataStreamProcessor(0, publisher, broker)
+	//kink model parameters
+	var a, b, c float64
+	a = 0
+	b = 0
+	c = 10
+
+	raw := make([]RawType, 800)
+	kinkList := []float64{100, 200.1, 300.5, 400.9, 460, 500, 540, 700}
+	kinkListFrameIndex := make([]FrameIndex, len(kinkList))
+	for i := 0; i < len(kinkList); i++ {
+		k := kinkList[i]
+		kint := int(math.Ceil(k))
+		for j := kint - 6; j < kint+20; j++ {
+			raw[j] = RawType(math.Round(kinkModel(k, float64(j), a, b, c)))
+			if j == kint+19 {
+				raw[j] = RawType(kint) // make it easier to figure out which trigger you are looking at if you print raw
+			}
+		}
+		kinkListFrameIndex[i] = FrameIndex(kint)
+	}
+	fmt.Println(raw)
+	dsp.NPresamples = 50
+	dsp.NSamples = 100
+
+	dsp.EdgeTrigger = true
+	dsp.EdgeMulti = true
+	dsp.EdgeRising = true
+	dsp.EdgeLevel = 10000
+	// should yield a single edge trigger
+	testTriggerSubroutine(t, raw, dsp, "EdgeMulti A: level too high", []FrameIndex{})
+	dsp.EdgeLevel = 1
+	dsp.LastEdgeMultiTrigger = 0 // need to reset this each time
+	// here we will find all triggers in trigInds, but triggers that are too short are not recordized
+	// the kinks that occur at fractional samples will end up the rounded value
+	// ideally 200.1 should trigger at 201, but since we only check k values in 0.5 step increments, we miss it
+	// my tests suggest testing at 0.5 step increments is ok on real data (eg a set of data from the Raven backup array test in 2018)
+	testTriggerSubroutine(t, raw, dsp, "EdgeMulti B", []FrameIndex{100, 200, 301, 401, 700})
+	dsp.EdgeMultiMakeContaminatedRecords = true
+	dsp.LastEdgeMultiTrigger = 0 // need to reset this each time
+	// here we will find all triggers in trigInds, and contaminated records will be created
+	primaries, _ := testTriggerSubroutine(t, raw, dsp, "EdgeMulti C", []FrameIndex{100, 200, 301, 401, 460, 500, 540, 700})
+	for _, record := range primaries {
+		if len(record.data) != dsp.NSamples {
+			t.Errorf("EdgeMulti C record has wrong number of samples %v", record)
+		}
+	}
+	dsp.EdgeMultiMakeContaminatedRecords = false
+	dsp.EdgeMultiMakeShortRecords = true
+	dsp.LastEdgeMultiTrigger = 0 // need to reset this each time
+	// here we will find all triggers in trigInds, and short records will be created
+	primaries, _ = testTriggerSubroutine(t, raw, dsp, "EdgeMulti D", []FrameIndex{100, 200, 301, 401, 460, 500, 540, 700})
+	///                                                                 lengths   100, 100, 100, 100, 49,  40,  50,  100
+	expect_lengths := []int{100, 100, 100, 100, 49, 40, 50, 100}
+	for i, record := range primaries {
+		if len(record.data) != expect_lengths[i] {
+			//if true {
+			t.Errorf("EdgeMulti D record %v: expect_len %v, len %v, presamples %v, trigFrame %v, %v:%v", i, expect_lengths[i],
+				len(record.data), record.presamples, record.trigFrame, int(record.trigFrame)-record.presamples, int(record.trigFrame)-record.presamples+len(record.data)-1)
+		}
+	}
 }
 
 // TestEdgeVetosLevel tests that an edge trigger vetoes a level trigger as needed.

--- a/triggering_test.go
+++ b/triggering_test.go
@@ -457,7 +457,7 @@ func BenchmarkLevelTrigger0TriggersOpsAreSamples(b *testing.B) {
 
 }
 
-func TestKinkModelResult(t *testing.T) {
+func TestKinkModel(t *testing.T) {
 	xdata := []float64{0, 1, 2, 3, 4, 5, 6, 7}
 	ydata := []float64{0, 0, 0, 0, 1, 2, 3, 4}
 	ymodel, a, b, c, X2, err := kinkModelResult(3, xdata, ydata)
@@ -468,5 +468,9 @@ func TestKinkModelResult(t *testing.T) {
 	if a != 0.6818181818181821 || b != 0.22727272727272738 ||
 		c != 1.1363636363636362 || X2 != 0.45454545454545453 || err != nil {
 		t.Errorf("a %v, b %v, c %v, X2 %v, err %v, ymodel %v", a, b, c, X2, err, ymodel)
+	}
+	kbest, X2min, err := kinkModelFit(xdata, ydata, []float64{1, 2, 2.5, 3, 3.5, 4, 5})
+	if kbest != 3 || X2min != 0 || err != nil {
+		t.Errorf("kbest %v, X2min %v, err %v", kbest, X2min, err)
 	}
 }


### PR DESCRIPTION
This adds an experimental `EdgeMulti` triggering mode with tests. It's incompatible with other trigger modes, and only triggers on rising edges, but I think it's worth merging in so we can test it with actual data sources. It's works basically how we discussed
1. Look for a difference between two points larger than a threshold. Call this i_potential. In my testing offline I found that if you do the kink model, it doesn't matter much how you got i_potential, so I used the easiest method.
2. Look for a local maximum following i_potential.
3. Use  6 samples before and 3 samples after i_potential to fit a kink model looking at values -1,-0.5-,0.5,1 relative to i_potential. Note kbest as a trigger.
4. Go through all sets of t,u,v where t is the index of the last trigger, u is the current trigger, v is the next trigger, and make records. There are a couple of settings, but the MakeShortRecords setting makes records greedy after a trigger, and makes records as large as possible with no shared samples.

It would be pretty easy to support negative going edges, and it would fairly easy to support auto triggers of some sort coexisting.

`AnalyzeData` works with records of `length<=dsp.NSamples`. Note that the standard analysis quantities are almost all NaN when `rec.presamples=0`