### PR TITLE
Allow port numbers to vary, so testing can use different ports

### DIFF
--- a/cmd/dastard/dastard.go
+++ b/cmd/dastard/dastard.go
@@ -74,6 +74,6 @@ func main() {
 	}
 
 	messageChan := make(chan dastard.ClientUpdate)
-	go dastard.RunClientUpdater(messageChan, dastard.ports.Status)
-	dastard.RunRPCServer(messageChan, dastard.ports.RPC)
+	go dastard.RunClientUpdater(messageChan, dastard.Ports.Status)
+	dastard.RunRPCServer(messageChan, dastard.Ports.RPC)
 }

--- a/cmd/dastard/dastard.go
+++ b/cmd/dastard/dastard.go
@@ -74,6 +74,6 @@ func main() {
 	}
 
 	messageChan := make(chan dastard.ClientUpdate)
-	go dastard.RunClientUpdater(messageChan, dastard.PortStatus)
-	dastard.RunRPCServer(messageChan, dastard.PortRPC)
+	go dastard.RunClientUpdater(messageChan, dastard.ports.Status)
+	dastard.RunRPCServer(messageChan, dastard.ports.RPC)
 }

--- a/networking.go
+++ b/networking.go
@@ -9,12 +9,12 @@ type Portnumbers struct {
 	Summaries      int
 }
 
-var ports = Portnumbers{5500, 5501, 5502, 5503, 5504}
+var Ports = Portnumbers{5500, 5501, 5502, 5503, 5504}
 
 func setPortnumbers(base int) {
-	ports.RPC = base
-	ports.Status = base + 1
-	ports.Trigs = base + 2
-	ports.SecondaryTrigs = base + 3
-	ports.Summaries = base + 4
+	Ports.RPC = base
+	Ports.Status = base + 1
+	Ports.Trigs = base + 2
+	Ports.SecondaryTrigs = base + 3
+	Ports.Summaries = base + 4
 }

--- a/networking.go
+++ b/networking.go
@@ -1,6 +1,6 @@
 package dastard
 
-// Portnumbers holds all TCP port numbers used by Dastard.
+// Portnumbers structs can contain all TCP port numbers used by Dastard.
 type Portnumbers struct {
 	RPC            int
 	Status         int
@@ -9,7 +9,12 @@ type Portnumbers struct {
 	Summaries      int
 }
 
-var Ports = Portnumbers{5500, 5501, 5502, 5503, 5504}
+// Ports globally holds all TCP port numbers used by Dastard.
+var Ports Portnumbers
+
+func init() {
+	setPortnumbers(5500)
+}
 
 func setPortnumbers(base int) {
 	Ports.RPC = base

--- a/networking.go
+++ b/networking.go
@@ -1,10 +1,20 @@
 package dastard
 
-// TCP port numbers used by Dastard.
-const (
-	PortRPC int = 5500 + iota
-	PortStatus
-	PortTrigs
-	PortSecondaryTrigs
-	PortSummaries
-)
+// Portnumbers holds all TCP port numbers used by Dastard.
+type Portnumbers struct {
+	RPC            int
+	Status         int
+	Trigs          int
+	SecondaryTrigs int
+	Summaries      int
+}
+
+var ports = Portnumbers{5500, 5501, 5502, 5503, 5504}
+
+func setPortnumbers(base int) {
+	ports.RPC = base
+	ports.Status = base + 1
+	ports.Trigs = base + 2
+	ports.SecondaryTrigs = base + 3
+	ports.Summaries = base + 4
+}

--- a/publish_data.go
+++ b/publish_data.go
@@ -233,7 +233,7 @@ func configurePubRecordsSocket() (err error) {
 	if PubRecordsChan != nil {
 		return fmt.Errorf("run configurePubRecordsSocket only one time")
 	}
-	PubRecordsChan, err = startSocket(PortTrigs, messageRecords)
+	PubRecordsChan, err = startSocket(ports.Trigs, messageRecords)
 	return
 }
 
@@ -242,7 +242,7 @@ func configurePubSummariesSocket() (err error) {
 	if PubSummariesChan != nil {
 		return fmt.Errorf("run configurePubSummariesSocket only one time")
 	}
-	PubSummariesChan, err = startSocket(PortSummaries, messageRecords)
+	PubSummariesChan, err = startSocket(ports.Summaries, messageRecords)
 	return
 }
 

--- a/publish_data.go
+++ b/publish_data.go
@@ -233,7 +233,7 @@ func configurePubRecordsSocket() (err error) {
 	if PubRecordsChan != nil {
 		return fmt.Errorf("run configurePubRecordsSocket only one time")
 	}
-	PubRecordsChan, err = startSocket(ports.Trigs, messageRecords)
+	PubRecordsChan, err = startSocket(Ports.Trigs, messageRecords)
 	return
 }
 
@@ -242,7 +242,7 @@ func configurePubSummariesSocket() (err error) {
 	if PubSummariesChan != nil {
 		return fmt.Errorf("run configurePubSummariesSocket only one time")
 	}
-	PubSummariesChan, err = startSocket(ports.Summaries, messageRecords)
+	PubSummariesChan, err = startSocket(Ports.Summaries, messageRecords)
 	return
 }
 

--- a/rpc_server_test.go
+++ b/rpc_server_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func simpleClient() (*rpc.Client, error) {
-	serverAddress := fmt.Sprintf("localhost:%d", PortRPC)
+	serverAddress := fmt.Sprintf("localhost:%d", ports.RPC)
 	retries := 5
 	wait := 10 * time.Millisecond
 	tries := 1
@@ -248,6 +248,9 @@ func setupViper() error {
 	if err != nil {             // Handle errors reading the config file
 		return fmt.Errorf("error reading config file: %s", err)
 	}
+
+	// Set up different ports for testing than you'd use otherwise
+	setPortnumbers(33000)
 	return nil
 }
 
@@ -259,8 +262,8 @@ func TestMain(m *testing.M) {
 
 	// call flag.Parse() here if TestMain uses flags
 	messageChan := make(chan ClientUpdate)
-	go RunClientUpdater(messageChan, PortStatus)
-	go RunRPCServer(messageChan, PortRPC)
+	go RunClientUpdater(messageChan, ports.Status)
+	go RunRPCServer(messageChan, ports.RPC)
 	// set log to write to a file
 	f, err := os.Create("dastardtestlogfile")
 	if err != nil {

--- a/rpc_server_test.go
+++ b/rpc_server_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func simpleClient() (*rpc.Client, error) {
-	serverAddress := fmt.Sprintf("localhost:%d", ports.RPC)
+	serverAddress := fmt.Sprintf("localhost:%d", Ports.RPC)
 	retries := 5
 	wait := 10 * time.Millisecond
 	tries := 1
@@ -262,8 +262,8 @@ func TestMain(m *testing.M) {
 
 	// call flag.Parse() here if TestMain uses flags
 	messageChan := make(chan ClientUpdate)
-	go RunClientUpdater(messageChan, ports.Status)
-	go RunRPCServer(messageChan, ports.RPC)
+	go RunClientUpdater(messageChan, Ports.Status)
+	go RunRPCServer(messageChan, Ports.RPC)
 	// set log to write to a file
 	f, err := os.Create("dastardtestlogfile")
 	if err != nil {


### PR DESCRIPTION
This prevents tests from messing with a running dastard server.