### PR TITLE
Lancero no hardware

### DIFF
--- a/data_source.go
+++ b/data_source.go
@@ -59,26 +59,21 @@ func Start(ds DataSource) error {
 	if ds.Running() {
 		return fmt.Errorf("cannot Start() a source that's already Running()")
 	}
-	fmt.Println("a")
 	if err := ds.Sample(); err != nil {
 		return err
 	}
-	fmt.Println("b")
 
 	if err := ds.PrepareRun(); err != nil {
 		return err
 	}
-	fmt.Println("c")
 
 	if err := ds.StartRun(); err != nil {
 		return err
 	}
-	fmt.Println("d")
 
 	// Have the DataSource produce data until graceful stop.
 	go func() {
 		for {
-			fmt.Println("e")
 			if err := ds.blockingRead(); err == io.EOF {
 				break
 			} else if err != nil {

--- a/data_source.go
+++ b/data_source.go
@@ -55,18 +55,26 @@ func Start(ds DataSource) error {
 	if ds.Running() {
 		return fmt.Errorf("cannot Start() a source that's already Running()")
 	}
+	fmt.Println("a")
 	if err := ds.Sample(); err != nil {
 		return err
 	}
+	fmt.Println("b")
+
 	if err := ds.PrepareRun(); err != nil {
 		return err
 	}
+	fmt.Println("c")
+
 	if err := ds.StartRun(); err != nil {
 		return err
 	}
+	fmt.Println("d")
+
 	// Have the DataSource produce data until graceful stop.
 	go func() {
 		for {
+			fmt.Println("e")
 			if err := ds.blockingRead(); err == io.EOF {
 				break
 			} else if err != nil {

--- a/lancero/lancero.go
+++ b/lancero/lancero.go
@@ -114,7 +114,8 @@ func (lan *Lancero) StopCollector() error {
 	return lan.collector.stop()
 }
 
-// Wait blocks until there is data in the ring buffer adapter.
+// Wait until a the threshold amount of data is available.
+// Return timestamp when ready, duration since last ready, and error.
 func (lan *Lancero) Wait() (time.Time, time.Duration, error) {
 	return lan.adapter.wait()
 }

--- a/lancero/lancero.go
+++ b/lancero/lancero.go
@@ -11,6 +11,22 @@ import (
 	"time"
 )
 
+// Lanceroer is the interaface shared by Lancero and NoHardware
+// used to allow testing without lancero hardware
+type Lanceroer interface {
+	ChangeRingBuffer(int, int) error
+	Close() error
+	StartAdapter(int) error
+	StopAdapter() error
+	CollectorConfigure(int, int, uint32, int) error
+	StartCollector(bool) error
+	StopCollector() error
+	Wait() (time.Time, time.Duration, error)
+	AvailableBuffers() ([]byte, error)
+	ReleaseBytes(int) error
+	InspectAdapter() uint32
+}
+
 // Notes:
 // Want 4 objects:
 // Lancero (high-level, exported). This isn't in the C++ version.
@@ -54,7 +70,7 @@ func (lan *Lancero) ChangeRingBuffer(length, threshold int) error {
 }
 
 // Close releases all resources used by this lancero device.
-func (lan *Lancero) Close() {
+func (lan *Lancero) Close() error {
 	if lan.device != nil {
 		lan.device.Close()
 	}
@@ -65,6 +81,7 @@ func (lan *Lancero) Close() {
 		lan.adapter.stop()
 		lan.adapter.freeBuffer()
 	}
+	return nil
 }
 
 // StartAdapter starts the ring buffer adapter, waiting up to waitSeconds sec for it to work.

--- a/lancero/lancero.go
+++ b/lancero/lancero.go
@@ -185,8 +185,8 @@ func OdDashTX(b []byte, maxLines int) string {
 	repeatCount := int(0)
 	outBuffer.WriteString(fmt.Sprintf("dumping %v bytes, output max lines %v\n", len(b), maxLines))
 	outBuffer.WriteString("L = least significant byte, M = most significant byte\n")
-	outBuffer.WriteString("framebit in errL\n")
-	outBuffer.WriteString("errMerrL fbkMfdbL errMerrL fbkMfdbL errMerrL fbkMfdbL errMerrL fbkMfdbL\n")
+	outBuffer.WriteString("framebit in fbkL\n")
+	outBuffer.WriteString("errLerrM fbkLfdbM errLerrM fbkLfdbM errLerrM fbkLfdbM errLerrM fbkLfdbM \n")
 	lines := 0
 	for i := 0; i < len(b) && lines < maxLines; i++ {
 		encoder.Write([]byte{b[i]})

--- a/lancero/lancero.go
+++ b/lancero/lancero.go
@@ -178,16 +178,17 @@ func FindFrameBits(b []byte) (int, int, int, error) {
 }
 
 // OdDashTX creates output like od -xt, used for debugging Lancero
-func OdDashTX(b []byte) string {
+func OdDashTX(b []byte, maxLines int) string {
 	var lineBuffer, outBuffer bytes.Buffer
 	var line, lastLine string
 	encoder := hex.NewEncoder(&lineBuffer)
 	repeatCount := int(0)
-	outBuffer.WriteString(fmt.Sprintf("dumping %v bytes\n", len(b)))
+	outBuffer.WriteString(fmt.Sprintf("dumping %v bytes, output max lines %v\n", len(b), maxLines))
 	outBuffer.WriteString("L = least significant byte, M = most significant byte\n")
 	outBuffer.WriteString("framebit in errL\n")
 	outBuffer.WriteString("errMerrL fbkMfdbL errMerrL fbkMfdbL errMerrL fbkMfdbL errMerrL fbkMfdbL\n")
-	for i := 0; i < len(b); i++ {
+	lines := 0
+	for i := 0; i < len(b) && lines < maxLines; i++ {
 		encoder.Write([]byte{b[i]})
 		if (i+1)%4 == 0 {
 			lineBuffer.WriteString(" ")
@@ -201,9 +202,11 @@ func OdDashTX(b []byte) string {
 				if repeatCount > 0 {
 					outBuffer.WriteString(fmt.Sprintf("* (%v identical lines)\n", repeatCount))
 					repeatCount = 0
+					lines++
 				}
 				outBuffer.WriteString(line)
 				outBuffer.WriteString("\n")
+				lines++
 				lastLine = line
 			}
 		}

--- a/lancero/lancero.go
+++ b/lancero/lancero.go
@@ -144,6 +144,7 @@ func (lan *Lancero) InspectAdapter() uint32 {
 // n number of consecutive words with frame bit set, starting at q
 // err is nil if q,p,n all found as expected
 func FindFrameBits(b []byte) (int, int, int, error) {
+	fmt.Println("in FindFrameBits")
 	const frameMask = byte(1)
 	var q, p, n int
 

--- a/lancero/lancero_adapter.go
+++ b/lancero/lancero_adapter.go
@@ -37,7 +37,8 @@ const (
 	bitsAdapterCtrlIEFlush  uint32 = 16 // Adapter control bit: flush buffer
 	bitsAdapterCtrlRunFlush uint32 = bitsAdapterCtrlRun | bitsAdapterCtrlIEFlush
 
-	HardMaxBufSize uint32 = 40 * (1 << 20) // Longest allowed adapter buffer
+	// HardMaxBufSize Longest allowed adapter buffer
+	HardMaxBufSize uint32 = 40 * (1 << 20)
 	// For latest value, look in driver lancero/Lancero-RELEASE/C/driver/lancero-base.c
 	// for the line that reads #define LANCERO_TRANSFER_MAX_BYTES (40 * (1<<20))
 )

--- a/lancero/lancero_test.go
+++ b/lancero/lancero_test.go
@@ -125,23 +125,6 @@ func TestOdDashTX(t *testing.T) {
 	}
 }
 
-func TestOdDashTX(t *testing.T) {
-	b := make([]byte, 10000)
-	if s := OdDashTX(b, 15); len(s) != 281 {
-		t.Errorf("have %v\n\n WRONG LENGTH, have %v, want 281", s, len(s))
-	}
-	for i := range b {
-		b[i] = byte(i)
-	}
-	if s := OdDashTX(b, 15); len(s) != 1280 {
-		t.Errorf("have %v\n\n WRONG LENGTH, have %v, want 1280", s, len(s))
-	}
-	b = make([]byte, 0)
-	if s := OdDashTX(b, 15); len(s) != 181 {
-		t.Errorf("have %v\n\n WRONG LENGTH, have %v, want 181", s, len(s))
-	}
-}
-
 // Imperfect round to nearest integer
 func roundint(x float64) int {
 	return int(x + math.Copysign(0.5, x))

--- a/lancero/lancero_test.go
+++ b/lancero/lancero_test.go
@@ -110,18 +110,18 @@ func testLanceroerSubroutine(lan Lanceroer, t *testing.T) (int, int, int, error)
 
 func TestOdDashTX(t *testing.T) {
 	b := make([]byte, 10000)
-	if s := OdDashTX(b, 15); len(s) != 280 {
-		t.Errorf("have %v\n\n WRONG LENGTH, have %v, want 280", s, len(s))
+	if s := OdDashTX(b, 15); len(s) != 281 {
+		t.Errorf("have %v\n\n WRONG LENGTH, have %v, want 281", s, len(s))
 	}
 	for i := range b {
 		b[i] = byte(i)
 	}
-	if s := OdDashTX(b, 15); len(s) != 1279 {
-		t.Errorf("have %v\n\n WRONG LENGTH, have %v, want 1279", s, len(s))
+	if s := OdDashTX(b, 15); len(s) != 1280 {
+		t.Errorf("have %v\n\n WRONG LENGTH, have %v, want 1280", s, len(s))
 	}
 	b = make([]byte, 0)
-	if s := OdDashTX(b, 15); len(s) != 180 {
-		t.Errorf("have %v\n\n WRONG LENGTH, have %v, want 180", s, len(s))
+	if s := OdDashTX(b, 15); len(s) != 181 {
+		t.Errorf("have %v\n\n WRONG LENGTH, have %v, want 181", s, len(s))
 	}
 }
 

--- a/lancero/lancero_test.go
+++ b/lancero/lancero_test.go
@@ -110,18 +110,18 @@ func testLanceroerSubroutine(lan Lanceroer, t *testing.T) (int, int, int, error)
 
 func TestOdDashTX(t *testing.T) {
 	b := make([]byte, 10000)
-	if s := OdDashTX(b); len(s) != 259 {
-		t.Errorf("have %v\n\n WRONG LENGTH, have %v, want 259", s, len(s))
+	if s := OdDashTX(b, 15); len(s) != 280 {
+		t.Errorf("have %v\n\n WRONG LENGTH, have %v, want 280", s, len(s))
 	}
-	for i, _ := range b {
+	for i := range b {
 		b[i] = byte(i)
 	}
-	if s := OdDashTX(b); len(s) != 22939 {
-		t.Errorf("have %v\n\n WRONG LENGTH, have %v, want 22939", s, len(s))
+	if s := OdDashTX(b, 15); len(s) != 1279 {
+		t.Errorf("have %v\n\n WRONG LENGTH, have %v, want 1279", s, len(s))
 	}
 	b = make([]byte, 0)
-	if s := OdDashTX(b); len(s) != 159 {
-		t.Errorf("have %v\n\n WRONG LENGTH, have %v, want 159", s, len(s))
+	if s := OdDashTX(b, 15); len(s) != 180 {
+		t.Errorf("have %v\n\n WRONG LENGTH, have %v, want 180", s, len(s))
 	}
 }
 

--- a/lancero/lancero_test.go
+++ b/lancero/lancero_test.go
@@ -23,6 +23,9 @@ func TestLancero(t *testing.T) {
 	fmt.Printf("Found lancero devices %v\n", devs)
 	devnum := devs[0]
 	lan, err := NewLancero(devnum)
+	if err != nil {
+		t.Error(err)
+	}
 	defer lan.Close()
 	testLanceroerSubroutine(lan, t)
 }
@@ -89,7 +92,6 @@ func testLanceroerSubroutine(lan Lanceroer, t *testing.T) (int, int, int, error)
 					spew.Println(buffer)
 					fmt.Println(q, p, n)
 					return 0, 0, 0, err
-					break
 				}
 				fmt.Println(q, p, bytesPerFrame, n, err)
 				nrows = (p - q) / n

--- a/lancero/no_hardware.go
+++ b/lancero/no_hardware.go
@@ -1,0 +1,149 @@
+package lancero
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+// NoHardware is a drop in replacement for Lancero (implements Lanceroer)
+// that requires not hardware
+// for testing
+type NoHardware struct {
+	ncols                    int
+	nrows                    int
+	linePeriod               int
+	nanoSecondsPerLinePeriod int
+	isOpen                   bool
+	isStarted                bool
+	collectorStarted         bool
+	bytesReleased            int
+	lastReadTime             time.Time
+	minTimeBetweenReads      time.Duration
+	byteCounter              int
+}
+
+// NewNoHardware generates and returns a new Lancero object in test mode,
+// meaning it emulate a lancero without any hardware
+func NewNoHardware(ncols int, nrows int, linePeriod int) (*NoHardware, error) {
+	lan := NoHardware{ncols: ncols, nrows: nrows, linePeriod: linePeriod,
+		nanoSecondsPerLinePeriod: 8, isOpen: true, lastReadTime: time.Now(),
+		minTimeBetweenReads: 10 * time.Millisecond}
+	return &lan, nil
+}
+
+//ChangeRingBuffer doesnt error
+func (lan *NoHardware) ChangeRingBuffer(length, threshold int) error {
+	return nil
+}
+
+// Close errors if already closed
+func (lan *NoHardware) Close() error {
+	if !lan.isOpen {
+		return fmt.Errorf("already closed")
+	}
+	lan.isOpen = false
+	return nil
+}
+
+// StartAdapter errors if already started
+func (lan *NoHardware) StartAdapter(waitSeconds int) error {
+	if lan.isStarted {
+		return fmt.Errorf("already started")
+	}
+	lan.isStarted = true
+	return nil
+}
+
+// StopAdapter errors if not started
+func (lan *NoHardware) StopAdapter() error {
+	if !lan.isStarted {
+		return fmt.Errorf("not started")
+	}
+	lan.isStarted = true
+	return nil
+}
+
+// CollectorConfigure returns nil
+func (lan *NoHardware) CollectorConfigure(linePeriod, dataDelay int, channelMask uint32,
+	frameLength int) error {
+	return nil
+}
+
+// StartCollector errors if Collector Already Started
+func (lan *NoHardware) StartCollector(simulate bool) error {
+	if lan.collectorStarted {
+		return fmt.Errorf("collector started already")
+	}
+	lan.collectorStarted = true
+	return nil
+}
+
+// StopCollector errors if Collector not started
+func (lan *NoHardware) StopCollector() error {
+	if !lan.collectorStarted {
+		return fmt.Errorf("collector started already")
+	}
+	lan.collectorStarted = false
+	return nil
+}
+
+// Wait blocks for 1 milliseconds
+func (lan *NoHardware) Wait() (time.Time, time.Duration, error) {
+	sleepDuration := time.Until(lan.lastReadTime.Add(lan.minTimeBetweenReads))
+	time.Sleep(sleepDuration)
+	now := time.Now()
+	return now, now.Sub(lan.lastReadTime), nil
+}
+
+// AvailableBuffers some simulated data
+// size matches what you should get in 1 millisecond
+// all entries other than frame bits are zeros
+func (lan *NoHardware) AvailableBuffers() ([]byte, error) {
+	var buf bytes.Buffer
+	if !lan.isStarted {
+		return buf.Bytes(), fmt.Errorf("not started")
+	}
+	if !lan.collectorStarted {
+		return buf.Bytes(), fmt.Errorf("collector not started")
+	}
+	if !lan.isOpen {
+		return buf.Bytes(), fmt.Errorf("not open")
+	}
+	now := time.Now()
+	sinceLastReadNanoseconds := now.Sub(lan.lastReadTime).Nanoseconds()
+	lan.lastReadTime = now
+	frameDurationNanoseconds := lan.linePeriod * lan.nanoSecondsPerLinePeriod * lan.nrows
+	frames := int(sinceLastReadNanoseconds) / frameDurationNanoseconds
+	for i := 0; i < frames; i++ { // i counts frames
+		for row := 0; row < lan.nrows; row++ {
+			for col := 0; col < lan.ncols; col++ {
+				v := byte(uint8(lan.byteCounter))
+				lan.byteCounter++
+				if row == 0 {
+					// first row has frame bit
+					buf.Write([]byte{0x00, v, 0x01, v})
+				} else {
+					// all data is zeros
+					buf.Write([]byte{0x00, v, 0x00, v})
+				}
+			}
+		}
+
+	}
+	return buf.Bytes(), nil
+}
+
+// ReleaseBytes increments bytesReleased
+func (lan *NoHardware) ReleaseBytes(nBytes int) error {
+	lan.bytesReleased += nBytes
+	return nil
+}
+
+// InspectAdapter prints some info and returns 0
+func (lan *NoHardware) InspectAdapter() uint32 {
+	spew.Println(lan)
+	return uint32(0)
+}

--- a/lancero/no_hardware.go
+++ b/lancero/no_hardware.go
@@ -128,7 +128,7 @@ func (lan *NoHardware) AvailableBuffers() ([]byte, error) {
 	lan.lastReadTime = now
 	frameDurationNanoseconds := lan.linePeriod * lan.nanoSecondsPerLinePeriod * lan.nrows
 	frames := int(sinceLastRead.Nanoseconds()) / frameDurationNanoseconds
-	fmt.Printf("id %v read at %v", lan.idNum, time.Now())
+	fmt.Printf("id %v read at %v\n", lan.idNum, time.Now())
 	if sinceLastRead > 50*lan.minTimeBetweenReads {
 		return buf.Bytes(), fmt.Errorf("reads were %v apart, want < %v\n", sinceLastRead, 50*lan.minTimeBetweenReads)
 	}

--- a/lancero/no_hardware.go
+++ b/lancero/no_hardware.go
@@ -103,7 +103,6 @@ func (lan *NoHardware) StopCollector() error {
 // Wait sleeps until lastReadTime + minTimeBetweenReads
 func (lan *NoHardware) Wait() (time.Time, time.Duration, error) {
 	sleepDuration := time.Until(lan.lastReadTime.Add(lan.minTimeBetweenReads))
-	fmt.Println("sleepDuration", sleepDuration)
 	time.Sleep(sleepDuration)
 	now := time.Now()
 	return now, now.Sub(lan.lastReadTime), nil
@@ -128,9 +127,9 @@ func (lan *NoHardware) AvailableBuffers() ([]byte, error) {
 	lan.lastReadTime = now
 	frameDurationNanoseconds := lan.linePeriod * lan.nanoSecondsPerLinePeriod * lan.nrows
 	frames := int(sinceLastRead.Nanoseconds()) / frameDurationNanoseconds
-	fmt.Printf("id %v read at %v\n", lan.idNum, time.Now())
+	// fmt.Printf("id %v read at %v\n", lan.idNum, time.Now())
 	if sinceLastRead > 50*lan.minTimeBetweenReads {
-		return buf.Bytes(), fmt.Errorf("reads were %v apart, want < %v\n", sinceLastRead, 50*lan.minTimeBetweenReads)
+		return buf.Bytes(), fmt.Errorf("reads were %v apart, want < %v", sinceLastRead, 50*lan.minTimeBetweenReads)
 	}
 
 	for i := 0; i < frames; i++ { // i counts frames

--- a/lancero/no_hardware.go
+++ b/lancero/no_hardware.go
@@ -22,7 +22,7 @@ type NoHardware struct {
 	bytesReleased            int
 	lastReadTime             time.Time
 	minTimeBetweenReads      time.Duration
-	byteCounter              int
+	rowCount                 int
 }
 
 // NewNoHardware generates and returns a new Lancero object in test mode,
@@ -42,7 +42,7 @@ func (lan *NoHardware) ChangeRingBuffer(length, threshold int) error {
 // Close errors if already closed
 func (lan *NoHardware) Close() error {
 	if !lan.isOpen {
-		return fmt.Errorf("already closed")
+		return fmt.Errorf("NoHardware.Close: already closed")
 	}
 	lan.isOpen = false
 	return nil
@@ -51,7 +51,7 @@ func (lan *NoHardware) Close() error {
 // StartAdapter errors if already started
 func (lan *NoHardware) StartAdapter(waitSeconds int) error {
 	if lan.isStarted {
-		return fmt.Errorf("already started")
+		return fmt.Errorf("NoHardware.StartAdapter: already started")
 	}
 	lan.isStarted = true
 	return nil
@@ -60,7 +60,7 @@ func (lan *NoHardware) StartAdapter(waitSeconds int) error {
 // StopAdapter errors if not started
 func (lan *NoHardware) StopAdapter() error {
 	if !lan.isStarted {
-		return fmt.Errorf("not started")
+		return fmt.Errorf("NoHardware.StopAdapter: not started")
 	}
 	lan.isStarted = true
 	return nil
@@ -75,7 +75,7 @@ func (lan *NoHardware) CollectorConfigure(linePeriod, dataDelay int, channelMask
 // StartCollector errors if Collector Already Started
 func (lan *NoHardware) StartCollector(simulate bool) error {
 	if lan.collectorStarted {
-		return fmt.Errorf("collector started already")
+		return fmt.Errorf("NoHardware.StartCollector: collector started already")
 	}
 	lan.collectorStarted = true
 	return nil
@@ -84,17 +84,20 @@ func (lan *NoHardware) StartCollector(simulate bool) error {
 // StopCollector errors if Collector not started
 func (lan *NoHardware) StopCollector() error {
 	if !lan.collectorStarted {
-		return fmt.Errorf("collector started already")
+		return fmt.Errorf("NoHardware.StopCollector: collector stopped already")
 	}
 	lan.collectorStarted = false
 	return nil
 }
 
-// Wait blocks for 1 milliseconds
+// Wait sleeps until lastReadTime + minTimeBetweenReads
 func (lan *NoHardware) Wait() (time.Time, time.Duration, error) {
+	fmt.Println("waiting")
 	sleepDuration := time.Until(lan.lastReadTime.Add(lan.minTimeBetweenReads))
+	fmt.Println(sleepDuration)
 	time.Sleep(sleepDuration)
 	now := time.Now()
+	fmt.Println("done waiting")
 	return now, now.Sub(lan.lastReadTime), nil
 }
 
@@ -104,13 +107,13 @@ func (lan *NoHardware) Wait() (time.Time, time.Duration, error) {
 func (lan *NoHardware) AvailableBuffers() ([]byte, error) {
 	var buf bytes.Buffer
 	if !lan.isStarted {
-		return buf.Bytes(), fmt.Errorf("not started")
+		return buf.Bytes(), fmt.Errorf("err in NoHardware.AvailableBuffers: not started")
 	}
 	if !lan.collectorStarted {
-		return buf.Bytes(), fmt.Errorf("collector not started")
+		return buf.Bytes(), fmt.Errorf("err in NoHardware.AvailableBuffers: collector not started")
 	}
 	if !lan.isOpen {
-		return buf.Bytes(), fmt.Errorf("not open")
+		return buf.Bytes(), fmt.Errorf("err in NoHardware.AvailableBuffers: not open")
 	}
 	now := time.Now()
 	sinceLastReadNanoseconds := now.Sub(lan.lastReadTime).Nanoseconds()
@@ -120,8 +123,8 @@ func (lan *NoHardware) AvailableBuffers() ([]byte, error) {
 	for i := 0; i < frames; i++ { // i counts frames
 		for row := 0; row < lan.nrows; row++ {
 			for col := 0; col < lan.ncols; col++ {
-				v := byte(uint8(lan.byteCounter))
-				lan.byteCounter++
+				v := byte(uint8(lan.rowCount))
+				lan.rowCount++
 				if row == 0 {
 					// first row has frame bit
 					buf.Write([]byte{0x00, v, 0x01, v})

--- a/lancero/no_hardware_test.go
+++ b/lancero/no_hardware_test.go
@@ -1,0 +1,29 @@
+package lancero
+
+import (
+	"testing"
+)
+
+func TestNoHardware(t *testing.T) {
+	var ncolsSet, nrowsSet, linePeriodSet int
+	ncolsSet = 8
+	nrowsSet = 8
+	linePeriodSet = 20
+	lan, err := NewNoHardware(ncolsSet, nrowsSet, linePeriodSet)
+	if err != nil {
+		t.Error(err)
+	}
+	ncols, nrows, linePeriod, err := testLanceroerSubroutine(lan, t)
+	if err != nil {
+		t.Error(err)
+	}
+	if ncols != ncolsSet {
+		t.Errorf("want %v, have %v", ncolsSet, ncols)
+	}
+	if nrows != nrowsSet {
+		t.Errorf("want %v, have %v", nrowsSet, nrows)
+	}
+	if linePeriod != linePeriodSet {
+		t.Errorf("want %v, have %v", linePeriodSet, linePeriod)
+	}
+}

--- a/lancero_source.go
+++ b/lancero_source.go
@@ -350,12 +350,13 @@ func (ls *LanceroSource) StartRun() error {
 				continue
 			}
 			firstWord, _, _, err := lancero.FindFrameBits(bytes)
-			if firstWord > 0 {
-				bytesToRelease := 4 * firstWord
-				log.Printf("First frame bit at word %d, so release %d of %d bytes\n", firstWord, bytesToRelease, len(bytes))
-				lan.ReleaseBytes(bytesToRelease)
-			}
+			// should check for correct number of columns/rows again?
 			if err == nil {
+				if firstWord > 0 {
+					bytesToRelease := 4 * firstWord
+					log.Printf("First frame bit at word %d, so release %d of %d bytes\n", firstWord, bytesToRelease, len(bytes))
+					lan.ReleaseBytes(bytesToRelease)
+				}
 				success = true
 				break
 			}
@@ -445,6 +446,10 @@ func (ls *LanceroSource) distributeData(timestamp time.Time, wait time.Duration)
 		}
 		nchanPrevDevices += nchan
 	}
+
+	// Should look for external trigger bits here, either once per card or once per column
+	// Maybe check for frame bits in stream?
+
 	// Now send these data downstream. Here we permute data into the expected
 	// channel ordering: r0c0, r1c0, r2c0, etc via the chan2readoutOrder map.
 	// Backtrack to find the time associated with the first sample.

--- a/lancero_source.go
+++ b/lancero_source.go
@@ -343,8 +343,6 @@ func (ls *LanceroSource) StartRun() error {
 			}
 			bytes, err := lan.AvailableBuffers()
 			bytesRead += len(bytes)
-			// fmt.Println("len(bytes)", len(bytes))
-			// fmt.Println("err AvailableBuffers", err)
 			if err != nil {
 				return fmt.Errorf("error in AvailableBuffers: %v", err)
 			}
@@ -352,10 +350,6 @@ func (ls *LanceroSource) StartRun() error {
 				continue
 			}
 			firstWord, _, _, err := lancero.FindFrameBits(bytes)
-			// fmt.Println("firstword", firstWord)
-			// fmt.Println("err", err)
-			// fmt.Println(lancero.OdDashTX(bytes, 5))
-
 			if firstWord > 0 {
 				bytesToRelease := 4 * firstWord
 				log.Printf("First frame bit at word %d, so release %d of %d bytes\n", firstWord, bytesToRelease, len(bytes))
@@ -371,7 +365,6 @@ func (ls *LanceroSource) StartRun() error {
 			return fmt.Errorf("read %v bytes, did %v iterations", bytesRead, i)
 		}
 	}
-	fmt.Println("return nil")
 	return nil
 }
 

--- a/lancero_source.go
+++ b/lancero_source.go
@@ -37,7 +37,7 @@ type LanceroSource struct {
 	active            []*LanceroDevice
 	chan2readoutOrder []int
 	lastFbData        []RawType // used in mix calculation
-	MixFraction       []float64
+	Mix               []Mix
 	AnySource
 }
 
@@ -133,7 +133,7 @@ func (ls *LanceroSource) updateChanOrderMap() {
 	for _, dev := range ls.active {
 		nChannelsAllCards += dev.ncols * dev.nrows * 2
 	}
-	ls.MixFraction = make([]float64, nChannelsAllCards)
+	ls.Mix = make([]Mix, nChannelsAllCards)
 	ls.chan2readoutOrder = make([]int, nChannelsAllCards)
 	ls.lastFbData = make([]RawType, nChannelsAllCards)
 	nchanPrevDevices := 0
@@ -152,13 +152,13 @@ func (ls *LanceroSource) updateChanOrderMap() {
 // ConfigureMixFraction sets the MixFraction for the channel associated with ProcessorIndex
 // mix = fb + mixFraction*err
 func (ls *LanceroSource) ConfigureMixFraction(processorIndex int, mixFraction float64) error {
-	if processorIndex >= len(ls.MixFraction) || processorIndex < 0 {
+	if processorIndex >= len(ls.Mix) || processorIndex < 0 {
 		return fmt.Errorf("processorIndex %v out of bounds", processorIndex)
 	}
 	if processorIndex%2 == 0 {
 		return fmt.Errorf("proccesorIndex %v is even, only odd channels (feedback) allowed", processorIndex)
 	}
-	ls.MixFraction[processorIndex] = mixFraction
+	ls.Mix[processorIndex] = Mix{mixFraction: mixFraction}
 	return nil
 }
 
@@ -438,43 +438,9 @@ func (ls *LanceroSource) distributeData(timestamp time.Time, wait time.Duration)
 			for j := 0; j < len(data); j++ {
 				data[j] &= mask
 			}
-			mixFraction := ls.MixFraction[channum]
-			if mixFraction != 0 { // apply mix
-				// Retard the raw data stream by 1 sample so it can be mixed with
-				// the appropriate error sample. This corrects for a poor choice in the
-				// TDM firmware design, but so it goes.
-
-				// fb_physical[n] refers to the feedback signal applied during tick [n]
-				// err_physical[n] refers to the error signal measured during tick [n], eg with fb_physical[n] applied
-				// fb_data[n]=fb_physical[n+1]
-				// err_data[n]=err_physical[n]
-				// in words: at frame [n] we get data for the error measured at frame [n]
-				// and the feedback that will be applied during frame [n+1]
-				// we want
-				// mix[n] = fb_physical[n] + mixFraction * err_physical[n]
-				// so
-				// mix[n] = fb_data[n-1]   + mixFraction * err_data[n]
-				// or
-				// mix[n+1] = fb_data[n]   + mixFraction * err_data[n+1]
-				mix := make([]RawType, len(data))
-				mix[0] = ls.lastFbData[channum]
-				copy(mix[1:], data[0:len(data)-1])
-
-				errData := datacopies[ls.chan2readoutOrder[channum-1]]
-				for j := 0; j < len(data); j++ {
-					mixAmount := float64(errData[j]) * mixFraction
-					// Be careful not to overflow!
-					floatMixResult := mixAmount + float64(mix[j])
-					if floatMixResult >= math.MaxUint16 {
-						data[j] = math.MaxUint16
-					} else if floatMixResult < 0 {
-						data[j] = 0
-					} else {
-						data[j] = RawType(roundint(floatMixResult))
-					}
-				}
-				ls.lastFbData[channum] = data[len(data)-1]
-			}
+			mix := ls.Mix[channum]
+			errData := datacopies[ls.chan2readoutOrder[channum-1]]
+			mix.MixRetardFb(&data, &errData) // alters data in place
 		}
 		// TODO: replace framesPerSample=1 with the actual decimation level
 		seg := DataSegment{

--- a/lancero_source.go
+++ b/lancero_source.go
@@ -247,7 +247,7 @@ func (device *LanceroDevice) sampleCard() error {
 		}
 		log.Printf("waittime: %v\n", waittime)
 		log.Printf("Found buffer with %9d total bytes, bytes read previously=%10d\n", totalBytes, bytesRead)
-		//fmt.Println(lancero.OdDashTX(buffer))
+		fmt.Println(lancero.OdDashTX(buffer, 10))
 		q, p, n, err := lancero.FindFrameBits(buffer)
 		bytesPerFrame := 4 * (p - q)
 		if err != nil {

--- a/lancero_source.go
+++ b/lancero_source.go
@@ -221,6 +221,7 @@ func (device *LanceroDevice) sampleCard() error {
 	const tooManyBytes int = 1000000  // shouldn't need this many bytes to SampleData
 	const tooManyIterations int = 100 // nor this many reads of the lancero
 	for i := 0; i < tooManyIterations; i++ {
+		fmt.Println(i)
 		if bytesRead >= tooManyBytes && i > 1 { // we ignore first buffer, make sure we see 2nd
 			return fmt.Errorf("LanceroDevice.sampleCard read %d bytes, failed to find nrow*ncol",
 				bytesRead)
@@ -329,14 +330,17 @@ func (ls *LanceroSource) StartRun() error {
 				return fmt.Errorf("error in Wait: %v", err)
 			}
 			bytes, err := lan.AvailableBuffers()
+			fmt.Println("len(bytes)", len(bytes))
+			fmt.Println(err)
 			if err != nil {
 				return fmt.Errorf("error in AvailableBuffers: %v", err)
 			}
 			if len(bytes) <= 0 {
 				continue
 			}
-
+			spew.Dump(bytes)
 			firstWord, _, _, err := lancero.FindFrameBits(bytes)
+			fmt.Println("firstword", err)
 			if err == nil && firstWord > 0 {
 				bytesToRelease := 4 * firstWord
 				// bytesToRelease += ((len(bytes) - 4*firstWord) / device.frameSize) * device.frameSize
@@ -344,8 +348,10 @@ func (ls *LanceroSource) StartRun() error {
 				lan.ReleaseBytes(bytesToRelease)
 				break
 			}
+			fmt.Println("after firstWord")
 		}
 	}
+	fmt.Println("return nil")
 	return nil
 }
 

--- a/lancero_test.go
+++ b/lancero_test.go
@@ -74,8 +74,8 @@ func TestChannelOrder(t *testing.T) {
 
 func TestNoHardware(t *testing.T) {
 	var ncolsSet, nrowsSet, linePeriodSet, nLancero int
-	ncolsSet = 8
-	nrowsSet = 8
+	ncolsSet = 1
+	nrowsSet = 4
 	linePeriodSet = 20
 	nLancero = 1
 	source := new(LanceroSource)

--- a/lancero_test.go
+++ b/lancero_test.go
@@ -2,6 +2,7 @@ package dastard
 
 import (
 	"testing"
+	"time"
 
 	"github.com/usnistgov/dastard/lancero"
 )
@@ -76,7 +77,7 @@ func TestNoHardware(t *testing.T) {
 	ncolsSet = 8
 	nrowsSet = 8
 	linePeriodSet = 20
-	nLancero = 3
+	nLancero = 1
 	source := new(LanceroSource)
 	source.devices = make(map[int]*LanceroDevice, nLancero)
 	cardDelay := []int{0} // a single card delay value works for multiple cards
@@ -96,7 +97,7 @@ func TestNoHardware(t *testing.T) {
 
 	config := LanceroSourceConfig{ClockMhz: 125, CardDelay: cardDelay,
 		ActiveCards: make([]int, nLancero)}
-	if err := source.Configure(&config); err == nil {
+	if err := source.Configure(&config); err == nil && nLancero > 1 {
 		t.Error("expected error for re-using a device")
 	}
 	config = LanceroSourceConfig{ClockMhz: 125, CardDelay: cardDelay,
@@ -111,6 +112,8 @@ func TestNoHardware(t *testing.T) {
 	}
 	if err := Start(source); err != nil {
 		t.Error(err)
+		source.Stop()
+		return
 	}
 	defer source.Stop()
 	if err := source.ConfigureMixFraction(0, 1.0); err == nil {
@@ -119,7 +122,7 @@ func TestNoHardware(t *testing.T) {
 	if err := source.ConfigureMixFraction(1, 1.0); err != nil {
 		t.Error(err)
 	}
-	// time.Sleep(20 * time.Millisecond) // wait long enough for some data to be processed
+	time.Sleep(20 * time.Millisecond) // wait long enough for some data to be processed
 
 }
 

--- a/lancero_test.go
+++ b/lancero_test.go
@@ -2,7 +2,6 @@ package dastard
 
 import (
 	"testing"
-	"time"
 
 	"github.com/usnistgov/dastard/lancero"
 )
@@ -120,7 +119,7 @@ func TestNoHardware(t *testing.T) {
 	if err := source.ConfigureMixFraction(1, 1.0); err != nil {
 		t.Error(err)
 	}
-	time.Sleep(20 * time.Millisecond) // wait long enough for some data to be processed
+	// time.Sleep(20 * time.Millisecond) // wait long enough for some data to be processed
 
 }
 

--- a/lancero_test.go
+++ b/lancero_test.go
@@ -2,7 +2,6 @@ package dastard
 
 import (
 	"testing"
-	"time"
 
 	"github.com/usnistgov/dastard/lancero"
 )
@@ -72,13 +71,12 @@ func TestChannelOrder(t *testing.T) {
 	}
 }
 
-<<<<<<< HEAD
 func TestNoHardware(t *testing.T) {
 	var ncolsSet, nrowsSet, linePeriodSet, nLancero int
 	ncolsSet = 1
 	nrowsSet = 4
 	linePeriodSet = 20
-	nLancero = 1
+	nLancero = 3
 	source := new(LanceroSource)
 	source.devices = make(map[int]*LanceroDevice, nLancero)
 	cardDelay := []int{0} // a single card delay value works for multiple cards
@@ -111,24 +109,50 @@ func TestNoHardware(t *testing.T) {
 			t.Errorf("AvailableCards not populated corrects. AvailableCards %v", config.AvailableCards)
 		}
 	}
+
+	// This is essentially Start(source)
+	// if err := source.Sample(); err != nil {
+	// 	t.Error(err)
+	// }
+	//
+	// if err := source.PrepareRun(); err != nil {
+	// 	t.Error(err)
+	// }
+	//
+	// if err := source.StartRun(); err != nil {
+	// 	t.Error(err)
+	// }
+	//
+	// // Have the DataSource produce data until graceful stop.
+	// go func() {
+	// 	for i := 0; i < 100; i++ {
+	// 		if err := source.blockingRead(); err == io.EOF {
+	// 			break
+	// 		} else if err != nil {
+	// 			log.Printf("blockingRead returns Error: %s\n", err.Error())
+	// 			// break
+	// 		}
+	// 	}
+	// 	source.CloseOutputs()
+	// }()
+
 	if err := Start(source); err != nil {
-		t.Error(err)
 		source.Stop()
-		return
+		t.Fatal(err)
 	}
 	defer source.Stop()
+
+	// end Start(source)
 	if err := source.ConfigureMixFraction(0, 1.0); err == nil {
 		t.Error("expected error for mixing on even channel")
 	}
 	if err := source.ConfigureMixFraction(1, 1.0); err != nil {
 		t.Error(err)
 	}
-	time.Sleep(20 * time.Millisecond) // wait long enough for some data to be processed
+	// time.Sleep(20 * time.Millisecond) // wait long enough for some data to be processed
 
 }
 
-=======
->>>>>>> master
 func TestMix(t *testing.T) {
 	data := make([]RawType, 10)
 	errData := make([]RawType, len(data))

--- a/lancero_test.go
+++ b/lancero_test.go
@@ -2,6 +2,7 @@ package dastard
 
 import (
 	"testing"
+	"time"
 
 	"github.com/usnistgov/dastard/lancero"
 )
@@ -113,8 +114,12 @@ func TestNoHardware(t *testing.T) {
 		t.Error(err)
 	}
 	defer source.Stop()
-	if err := source.ConfigureMixFraction(0, 1.0); err != nil {
+	if err := source.ConfigureMixFraction(0, 1.0); err == nil {
+		t.Error("expected error for mixing on even channel")
+	}
+	if err := source.ConfigureMixFraction(1, 1.0); err != nil {
 		t.Error(err)
 	}
+	time.Sleep(50 * time.Millisecond)
 
 }

--- a/lancero_test.go
+++ b/lancero_test.go
@@ -2,6 +2,7 @@ package dastard
 
 import (
 	"testing"
+	"time"
 
 	"github.com/usnistgov/dastard/lancero"
 )
@@ -123,7 +124,7 @@ func TestNoHardwareSource(t *testing.T) {
 	if err := source.ConfigureMixFraction(1, 1.0); err != nil {
 		t.Error(err)
 	}
-	// time.Sleep(20 * time.Millisecond) // wait long enough for some data to be processed
+	time.Sleep(20 * time.Millisecond) // wait long enough for some data to be processed
 
 }
 

--- a/lancero_test.go
+++ b/lancero_test.go
@@ -71,7 +71,7 @@ func TestChannelOrder(t *testing.T) {
 	}
 }
 
-func TestNoHardware(t *testing.T) {
+func TestNoHardwareSource(t *testing.T) {
 	var ncolsSet, nrowsSet, linePeriodSet, nLancero int
 	ncolsSet = 1
 	nrowsSet = 4
@@ -109,32 +109,6 @@ func TestNoHardware(t *testing.T) {
 			t.Errorf("AvailableCards not populated corrects. AvailableCards %v", config.AvailableCards)
 		}
 	}
-
-	// This is essentially Start(source)
-	// if err := source.Sample(); err != nil {
-	// 	t.Error(err)
-	// }
-	//
-	// if err := source.PrepareRun(); err != nil {
-	// 	t.Error(err)
-	// }
-	//
-	// if err := source.StartRun(); err != nil {
-	// 	t.Error(err)
-	// }
-	//
-	// // Have the DataSource produce data until graceful stop.
-	// go func() {
-	// 	for i := 0; i < 100; i++ {
-	// 		if err := source.blockingRead(); err == io.EOF {
-	// 			break
-	// 		} else if err != nil {
-	// 			log.Printf("blockingRead returns Error: %s\n", err.Error())
-	// 			// break
-	// 		}
-	// 	}
-	// 	source.CloseOutputs()
-	// }()
 
 	if err := Start(source); err != nil {
 		source.Stop()

--- a/lancero_test.go
+++ b/lancero_test.go
@@ -1,7 +1,10 @@
 package dastard
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/usnistgov/dastard/lancero"
 )
 
 // TestChannelOrder checks the map from channel to readout numbering
@@ -67,4 +70,38 @@ func TestChannelOrder(t *testing.T) {
 			t.Errorf("roundint(%f)=%d, want %d", f, roundint(f), es[i])
 		}
 	}
+}
+
+func TestNoHardware(t *testing.T) {
+	var ncolsSet, nrowsSet, linePeriodSet int
+	ncolsSet = 8
+	nrowsSet = 8
+	linePeriodSet = 20
+	lan, err := lancero.NewNoHardware(ncolsSet, nrowsSet, linePeriodSet)
+	if err != nil {
+		t.Error(err)
+	}
+	dev := LanceroDevice{card: lan}
+	source := new(LanceroSource)
+	source.devices = make(map[int]*LanceroDevice)
+	source.devices[0] = &dev
+	source.ncards++
+	source.clockMhz = 125
+	// above is essentially NewLanceroSource
+
+	config := LanceroSourceConfig{ClockMhz: 125, CardDelay: []int{0},
+		ActiveCards: []int{0}, AvailableCards: []int{0}}
+	source.Configure(&config)
+	if err := source.StartRun(); err != nil {
+		t.Error(err)
+	}
+	fmt.Println("mix fraction")
+	source.ConfigureMixFraction(0, 1.0)
+	fmt.Println("ready for blockingRead")
+	if err := source.blockingRead(); err != nil {
+		t.Error(err)
+	}
+
+	panic("dont timeout")
+
 }

--- a/lancero_test.go
+++ b/lancero_test.go
@@ -112,11 +112,9 @@ func TestNoHardware(t *testing.T) {
 	if err := Start(source); err != nil {
 		t.Error(err)
 	}
-
+	defer source.Stop()
 	if err := source.ConfigureMixFraction(0, 1.0); err != nil {
 		t.Error(err)
 	}
-	if err := source.blockingRead(); err != nil {
-		t.Error(err)
-	}
+
 }

--- a/lancero_test.go
+++ b/lancero_test.go
@@ -120,6 +120,72 @@ func TestNoHardware(t *testing.T) {
 	if err := source.ConfigureMixFraction(1, 1.0); err != nil {
 		t.Error(err)
 	}
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond) // wait long enough for some data to be processed
+
+}
+
+func TestMix(t *testing.T) {
+	data := make([]RawType, 10)
+	errData := make([]RawType, len(data))
+	for i := range errData {
+		errData[i] = RawType(i * 4)
+
+	}
+	mix := Mix{mixFraction: 0}
+	mix.MixRetardFb(&data, &errData)
+	passed := true
+	for i := range data {
+		if data[i] != 0 {
+			passed = false
+		}
+	}
+	if !passed {
+		t.Errorf("want all zeros, have\n%v", data)
+	}
+	mix = Mix{mixFraction: 1}
+	mix.MixRetardFb(&data, &errData)
+	passed = true
+	for i := range data {
+		if data[i] != errData[i] {
+			passed = false
+		}
+	}
+	if !passed {
+		t.Errorf("want %v\n have\n%v", errData, data)
+	}
+	if mix.lastFb != 0 {
+		t.Errorf("want 0, have %v", mix.lastFb)
+	}
+	mix.lastFb = 100
+	mix.MixRetardFb(&data, &errData)
+	passed = true
+	expect := []RawType{100 + 0, (0 + 1) * 4, (1 + 2) * 4, (2 + 3) * 4,
+		(3 + 4) * 4, (4 + 5) * 4, (5 + 6) * 4, (6 + 7) * 4, (7 + 8) * 4, (8 + 9) * 4}
+	for i := range data {
+		if data[i] != expect[i] {
+			passed = false
+		}
+	}
+	if !passed {
+		t.Errorf("want %v\nhave\n%v", expect, data)
+	}
+	if mix.lastFb != 36 {
+		t.Errorf("want 36, have %v", mix.lastFb)
+	}
+	// test 2 LSBs of feedback are masked off
+	for i := range data {
+		data[i] = RawType(i % 4)
+	}
+	mix = Mix{mixFraction: 0}
+	mix.MixRetardFb(&data, &errData)
+	passed = true
+	for i := range data {
+		if data[i] != 0 {
+			passed = false
+		}
+	}
+	if !passed {
+		t.Errorf("want all zeros, have\n%v", data)
+	}
 
 }

--- a/mix.go
+++ b/mix.go
@@ -29,18 +29,6 @@ type Mix struct {
 // MixRetardFb mixes err into fbs, alters fbs in place to contain the mixed values
 // consecutive calls must be on consecutive data
 func (m *Mix) MixRetardFb(fbs *[]RawType, errs *[]RawType) {
-<<<<<<< HEAD
-	unmixed := make([]RawType, len(*fbs))
-	unmixed[0] = m.lastFb
-	copy(unmixed[1:], (*fbs)[0:len(unmixed)-1])
-	m.lastFb = (*fbs)[len(unmixed)-1]
-	const mask = ^RawType(0x03)
-	for j := 0; j < len(*fbs); j++ {
-		fb := unmixed[j] & mask
-		mixAmount := float64((*errs)[j]) * m.mixFraction
-		// Be careful not to overflow!
-		floatMixResult := mixAmount + float64(fb)
-=======
 	const mask = ^RawType(0x03)
 	for j := 0; j < len(*fbs); j++ {
 		fb := m.lastFb & mask
@@ -48,7 +36,6 @@ func (m *Mix) MixRetardFb(fbs *[]RawType, errs *[]RawType) {
 		// Be careful not to overflow!
 		floatMixResult := mixAmount + float64(fb)
 		m.lastFb = (*fbs)[j]
->>>>>>> master
 		if floatMixResult >= math.MaxUint16 {
 			(*fbs)[j] = math.MaxUint16
 		} else if floatMixResult < 0 {
@@ -57,8 +44,5 @@ func (m *Mix) MixRetardFb(fbs *[]RawType, errs *[]RawType) {
 			(*fbs)[j] = RawType(roundint(floatMixResult))
 		}
 	}
-<<<<<<< HEAD
-=======
 
->>>>>>> master
 }

--- a/mix.go
+++ b/mix.go
@@ -1,0 +1,50 @@
+package dastard
+
+import (
+	"math"
+)
+
+// Mix performns the mix for lancero data, handles retarding on datastream
+// Retard the raw data stream by 1 sample so it can be mixed with
+//
+// the appropriate error sample. This corrects for a poor choice in the
+// TDM firmware design, but so it goes.
+// fb_physical[n] refers to the feedback signal applied during tick [n]
+// err_physical[n] refers to the error signal measured during tick [n], eg with fb_physical[n] applied
+// fb_data[n]=fb_physical[n+1]
+// err_data[n]=err_physical[n]
+// in words: at frame [n] we get data for the error measured at frame [n]
+// and the feedback that will be applied during frame [n+1]
+// we want
+// mix[n] = fb_physical[n] + mixFraction * err_physical[n]
+// so
+// mix[n] = fb_data[n-1]   + mixFraction * err_data[n]
+// or
+// mix[n+1] = fb_data[n]   + mixFraction * err_data[n+1]
+type Mix struct {
+	mixFraction float64
+	lastFb      RawType
+}
+
+// MixRetardFb mixes err into fbs, alters fbs in place to contain the mixed values
+// consecutive calls must be on consecutive data
+func (m *Mix) MixRetardFb(fbs *[]RawType, errs *[]RawType) {
+	unmixed := make([]RawType, len(*fbs))
+	unmixed[0] = m.lastFb
+	copy(unmixed[1:], (*fbs)[0:len(unmixed)-1])
+	m.lastFb = (*fbs)[len(unmixed)-1]
+	const mask = ^RawType(0x03)
+	for j := 0; j < len(*fbs); j++ {
+		fb := unmixed[j] & mask
+		mixAmount := float64((*errs)[j]) * m.mixFraction
+		// Be careful not to overflow!
+		floatMixResult := mixAmount + float64(fb)
+		if floatMixResult >= math.MaxUint16 {
+			(*fbs)[j] = math.MaxUint16
+		} else if floatMixResult < 0 {
+			(*fbs)[j] = 0
+		} else {
+			(*fbs)[j] = RawType(roundint(floatMixResult))
+		}
+	}
+}


### PR DESCRIPTION
* `lancero.NoHardware`
* refactor Mix
* above enables test coverage of 93.3%
* adds `od -xt` like output by default on every attempt to find frame bits
