### PR TITLE
File writing of LJH 2.2 can be controlled by RPC

### DIFF
--- a/data_source.go
+++ b/data_source.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -34,6 +36,7 @@ type DataSource interface {
 	ConfigureProjectorsBases(int, mat.Dense, mat.Dense) error
 	ChangeTriggerState(*FullTriggerState) error
 	ConfigureMixFraction(int, float64) error
+	WriteControl(*WriteControlConfig) error
 }
 
 // ConfigureMixFraction provides a default implementation for all non-lancero sources that
@@ -100,6 +103,72 @@ type AnySource struct {
 // StartRun tells the hardware to switch into data streaming mode.
 // It's a no-op for simulated (software) sources
 func (ds *AnySource) StartRun() error {
+	return nil
+}
+
+// makeDirectory creates directory of the form basepath/20060102/000 where
+// the 3-digit subdirectory counts separate file-writing occasions.
+// It also returns the formatting code for use in an Sprintf call
+// basepath/20060102/000/20060102_run000_%s.ljh and an error, if any.
+func makeDirectory(basepath string) (string, error) {
+	today := time.Now().Format("20060102")
+	todayDir := fmt.Sprintf("%s/%s", basepath, today)
+	if err := os.MkdirAll(todayDir, 0755); err != nil {
+		return "", err
+	}
+	for i := 0; i < 1000; i++ {
+		thisDir := fmt.Sprintf("%s/%3.3d", todayDir, i)
+		_, err := os.Lstat(thisDir)
+		if err == os.ErrNotExist {
+			if err2 := os.MkdirAll(thisDir, 0755); err2 != nil {
+				return "", err
+			}
+			return fmt.Sprintf("%s/%s_run%3.3d_%%s.ljh", thisDir, today, i), nil
+		}
+	}
+	return "", fmt.Errorf("out of ID numbers for today in %s", todayDir)
+}
+
+// WriteControl changes the data writing start/stop/pause/unpause state
+func (ds *AnySource) WriteControl(config *WriteControlConfig) error {
+	if strings.HasPrefix(config.Request, "Pause") {
+		for _, dsp := range ds.processors {
+			dsp.DataPublisher.SetPause(true)
+		}
+	} else if strings.HasPrefix(config.Request, "Unpause") {
+		for _, dsp := range ds.processors {
+			dsp.DataPublisher.SetPause(false)
+		}
+	} else if strings.HasPrefix(config.Request, "Stop") {
+		for _, dsp := range ds.processors {
+			dsp.DataPublisher.RemoveLJH22()
+			dsp.DataPublisher.RemoveLJH3()
+		}
+	} else if strings.HasPrefix(config.Request, "Start") {
+		if config.FileType != "LJH2.2" {
+			return fmt.Errorf("WriteControl FileType=%q, needs to be %q",
+				config.FileType, "LJH2.2")
+		}
+		filenamePattern, err := makeDirectory(config.Path)
+		if err != nil {
+			return fmt.Errorf("Could not make directory: %s", err.Error())
+		}
+		for i, dsp := range ds.processors {
+			if dsp.DataPublisher.HasLJH22() {
+				return fmt.Errorf("WriteControl Request:Start is not yet implemented when writing already running")
+			}
+			timebase := 1.0 / dsp.SampleRate
+			var nrows, ncols int // default to 0 x 0 array
+			// TODO: update nrows, ncols for a Lancero source
+			filename := fmt.Sprintf(filenamePattern, dsp.Name)
+			var timestampOffset float64 // TODO: figure this out
+			dsp.DataPublisher.SetLJH22(i, dsp.NPresamples, dsp.NSamples, timebase, timestampOffset, nrows, ncols, filename)
+		}
+	} else {
+		return fmt.Errorf("WriteControl config.Request=%q, need (Start,Stop,Pause,Unpause)",
+			config.Request)
+	}
+
 	return nil
 }
 

--- a/data_source.go
+++ b/data_source.go
@@ -138,11 +138,13 @@ func (ds *AnySource) WriteControl(config *WriteControlConfig) error {
 			dsp.DataPublisher.SetPause(true)
 		}
 		ds.writingState.Paused = true
+
 	} else if strings.HasPrefix(config.Request, "Unpause") {
 		for _, dsp := range ds.processors {
 			dsp.DataPublisher.SetPause(false)
 		}
 		ds.writingState.Paused = false
+
 	} else if strings.HasPrefix(config.Request, "Stop") {
 		for _, dsp := range ds.processors {
 			dsp.DataPublisher.RemoveLJH22()
@@ -150,8 +152,8 @@ func (ds *AnySource) WriteControl(config *WriteControlConfig) error {
 		}
 		ds.writingState.Active = false
 		ds.writingState.Paused = false
-		ds.writingState.BasePath = config.Path
 		ds.writingState.Filename = ""
+
 	} else if strings.HasPrefix(config.Request, "Start") {
 		if config.FileType != "LJH2.2" {
 			return fmt.Errorf("WriteControl FileType=%q, needs to be %q",

--- a/data_source.go
+++ b/data_source.go
@@ -116,17 +116,17 @@ func makeDirectory(basepath string) (string, error) {
 	if err := os.MkdirAll(todayDir, 0755); err != nil {
 		return "", err
 	}
-	for i := 0; i < 1000; i++ {
-		thisDir := fmt.Sprintf("%s/%3.3d", todayDir, i)
-		_, err := os.Lstat(thisDir)
-		if err == os.ErrNotExist {
+	for i := 0; i < 10000; i++ {
+		thisDir := fmt.Sprintf("%s/%4.4d", todayDir, i)
+		_, err := os.Stat(thisDir)
+		if os.IsNotExist(err) {
 			if err2 := os.MkdirAll(thisDir, 0755); err2 != nil {
 				return "", err
 			}
-			return fmt.Sprintf("%s/%s_run%3.3d_%%s.ljh", thisDir, today, i), nil
+			return fmt.Sprintf("%s/%s_run%4.4d_%%s.ljh", thisDir, today, i), nil
 		}
 	}
-	return "", fmt.Errorf("out of ID numbers for today in %s", todayDir)
+	return "", fmt.Errorf("out of 4-digit ID numbers for today in %s", todayDir)
 }
 
 // WriteControl changes the data writing start/stop/pause/unpause state
@@ -209,7 +209,7 @@ func (ds *AnySource) setDefaultChannelNames() {
 	}
 	ds.chanNames = make([]string, ds.nchan)
 	for i := 0; i < ds.nchan; i++ {
-		ds.chanNames[i] = fmt.Sprintf("ch%d", i)
+		ds.chanNames[i] = fmt.Sprintf("chan%d", i)
 	}
 }
 

--- a/data_source_test.go
+++ b/data_source_test.go
@@ -1,0 +1,51 @@
+package dastard
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestChannelNames(t *testing.T) {
+	ds := AnySource{nchan: 4}
+	ds.setDefaultChannelNames()
+	expect := []string{"chan0", "chan1", "chan2", "chan3"}
+	if len(ds.chanNames) != 4 {
+		t.Errorf("ds.chanNames length = %d, want 4", len(ds.chanNames))
+	} else {
+		for i, n := range ds.chanNames {
+			if n != expect[i] {
+				t.Errorf("ds.chanNames[%d]=%q, want %q", i, n, expect[i])
+			}
+		}
+	}
+}
+
+func TestWritingFiles(t *testing.T) {
+	tmp, err1 := ioutil.TempDir("", "dastardTest")
+	if err1 != nil {
+		t.Errorf("could not make TempDir")
+		return
+	}
+	defer os.RemoveAll(tmp)
+
+	dir, err2 := makeDirectory(tmp)
+	if err2 != nil {
+		t.Error(err2)
+	} else if !strings.HasPrefix(dir, tmp) {
+		t.Errorf("Writing in path %s, which should be a prefix of %s", tmp, dir)
+	}
+	dir2, err2 := makeDirectory(tmp)
+	if err2 != nil {
+		t.Error(err2)
+	} else if !strings.HasPrefix(dir2, tmp) {
+		t.Errorf("Writing in path %s, which should be a prefix of %s", tmp, dir2)
+	} else if !strings.HasSuffix(dir2, "run0001_%s.ljh") {
+		t.Errorf("makeDirectory produces %s, of which %q should be a suffix", dir2, "run0001_%s.ljh")
+	}
+
+	if _, err := makeDirectory("/notallowed"); err == nil {
+		t.Errorf("makeDirectory(%s) should have failed", "/notallowed")
+	}
+}

--- a/ljh/ljh.go
+++ b/ljh/ljh.go
@@ -158,7 +158,9 @@ Number of columns: %d
 
 // Flush flushes buffered data to disk
 func (w Writer) Flush() {
-	w.writer.Flush()
+	if w.writer != nil {
+		w.writer.Flush()
+	}
 }
 
 // Close closes the associated file, no more records can be written after this

--- a/publish_data.go
+++ b/publish_data.go
@@ -19,6 +19,11 @@ type DataPublisher struct {
 	PubSummariesChan chan []*DataRecord
 	LJH22            *ljh.Writer
 	LJH3             *ljh.Writer3
+	writingPaused    bool
+}
+
+func (dp *DataPublisher) SetPause(pause bool) {
+	dp.writingPaused = pause
 }
 
 // SetLJH3 adds an LJH3 writer to dp, the .file attribute is nil, and will be instantiated upon next call to dp.WriteRecord
@@ -30,11 +35,12 @@ func (dp *DataPublisher) SetLJH3(ChanNum int, Timebase float64,
 		NumberOfColumns: NumberOfColumns,
 		FileName:        FileName}
 	dp.LJH3 = &w
+	dp.writingPaused = false
 }
 
 // HasLJH3 returns true if LJH3 is non-nil, eg if writing to LJH3 is occuring
 func (dp *DataPublisher) HasLJH3() bool {
-	return dp.LJH3 != nil
+	return dp.LJH3 != nil && !dp.writingPaused
 }
 
 // RemoveLJH3 closes existing LJH3 file and assign .LJH3=nil
@@ -57,11 +63,12 @@ func (dp *DataPublisher) SetLJH22(ChanNum int, Presamples int, Samples int, Time
 		NumberOfColumns: NumberOfColumns,
 		FileName:        FileName}
 	dp.LJH22 = &w
+	dp.writingPaused = false
 }
 
 // HasLJH22 returns true if LJH22 is non-nil, used to decide if writeint to LJH22 should occur
 func (dp *DataPublisher) HasLJH22() bool {
-	return dp.LJH22 != nil
+	return dp.LJH22 != nil && !dp.writingPaused
 }
 
 // RemoveLJH22 closes existing LJH22 file and assign .LJH22=nil

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -288,6 +288,27 @@ func (s *SourceControl) Stop(dummy *string, reply *bool) error {
 	return nil
 }
 
+// WriteControlConfig object to control start/stop/pause of data writing
+type WriteControlConfig struct {
+	Request   string // "Start", "Stop", "Pause", or "Unpause"
+	Path      string // write in a new directory under this path
+	FileType  string // "LJH2.2", "LJH3", or ... ?
+	Rec2Write int
+}
+
+// WriteControl requests start/stop/pause/unpause data writing
+func (s *SourceControl) WriteControl(config *WriteControlConfig, reply *bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	*reply = true
+	if s.activeSource == nil {
+		return nil
+	}
+	err := s.activeSource.WriteControl(config)
+	*reply = (err != nil)
+	return err
+}
+
 func (s *SourceControl) broadcastHeartbeat() {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -426,6 +426,11 @@ func RunRPCServer(messageChan chan<- ClientUpdate, portrpc int) {
 	if err == nil {
 		sourceControl.broadcastStatus()
 	}
+	var ws WritingState
+	err = viper.UnmarshalKey("writingstate", &ws)
+	if err == nil {
+		sourceControl.clientUpdates <- ClientUpdate{"WRITING", ws}
+	}
 
 	// Regularly broadcast a "heartbeat" containing data rate to all clients
 	go func() {


### PR DESCRIPTION
Added RPC commands `WriteControl` and `WriteComment`. The latter just adds (or replaces) a `comment.txt` file to the directory where LJH files are being written. The former has requests Start, Stop, Pause, and Unpause. If the request is Start, then the additional information is used to select file type (only LJH2.2 is valid so far), number of records (value is ignored), and the base path.

File naming works like this:
* RPC command fixes the `BasePath`. I would suggest changing this only once per cool down, but user can choose other methods. Because users gonna use. Let's suppose `BasePath="/data/2018A"`
* For the first file-set written on June 22, the directory will automatically be `/data/2018A/20180622/0000`, and the file names will be `/data/2018A/20180622/0000/20180622_run0000_chan1.ljh` and similar.
* For the next file-set written that day (determined by `time.Now()`), the last directory increments to `0001` and the files are named `20180622_run0001_chan*.ljh`.
* It is an error to try to write more than 10,000 LJH file-sets in one day. You can work around this by changing `BasePath`.

Still on the to do list are:

1. Allow user to specify a total number of records to write.
1. Allow LJH3 files to be written.
1. Get ncols x nrows info for Lancero data, also perhaps "card number 1 of 3" or whatever.
1. Figure out the timestamp offset for the LJH headers. Does this header item even make sense any more now that we're devoting 64 bits to the per-pulse timestamp? It was formerly used so that we could pack _relative_ timestamps into 4 (then later, 5) bytes in the LJH 2.0 and 2.1 formats, and this was a global timestamp added to those compressed per-pulse timestamps.
1. Emit some kind of information about how much data was written. I think this should be a message on the STATUS port, either part of the new `ALIVE` heartbeat message or its own new message. It would contain a channel-by-channel `[]int` with the number of records.

I propose that we merge Galen's PR about Lancero-without-hardware (#26) before this one. But after that, I this we should merge this even with those five to-do items still outstanding. I think they represent good but not essential features. We'll see how easy they are to knock out on Monday.