### PR TITLE
Trigger rate

### DIFF
--- a/cmd/dastard/dastard.go
+++ b/cmd/dastard/dastard.go
@@ -73,7 +73,6 @@ func main() {
 		panic(err)
 	}
 
-	messageChan := make(chan dastard.ClientUpdate)
-	go dastard.RunClientUpdater(messageChan, dastard.Ports.Status)
-	dastard.RunRPCServer(messageChan, dastard.Ports.RPC)
+	go dastard.RunClientUpdater(dastard.Ports.Status)
+	dastard.RunRPCServer(dastard.Ports.RPC)
 }

--- a/data_source.go
+++ b/data_source.go
@@ -251,9 +251,9 @@ func (ds *AnySource) ComputeFullTriggerState() []FullTriggerState {
 	for _, dsp := range ds.processors {
 		chans, ok := result[dsp.TriggerState]
 		if ok {
-			result[dsp.TriggerState] = append(chans, dsp.Channum)
+			result[dsp.TriggerState] = append(chans, dsp.channelIndex)
 		} else {
-			result[dsp.TriggerState] = []int{dsp.Channum}
+			result[dsp.TriggerState] = []int{dsp.channelIndex}
 		}
 	}
 
@@ -359,12 +359,12 @@ func (stream *DataStream) TrimKeepingN(N int) int {
 
 // DataRecord contains a single triggered pulse record.
 type DataRecord struct {
-	data       []RawType
-	trigFrame  FrameIndex
-	trigTime   time.Time
-	channum    int
-	presamples int
-	sampPeriod float32
+	data         []RawType
+	trigFrame    FrameIndex
+	trigTime     time.Time
+	channelIndex int
+	presamples   int
+	sampPeriod   float32
 
 	// trigger type?
 

--- a/group_trigger.go
+++ b/group_trigger.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 )
 
-// type receiverSet map[int]bool
-
 // TriggerBroker communicates with DataChannel objects to allow them to operate independently
 // yet still share group triggering information.
 type TriggerBroker struct {

--- a/process_data.go
+++ b/process_data.go
@@ -76,6 +76,7 @@ func NewDataStreamProcessor(chnum int, broker *TriggerBroker) *DataStreamProcess
 	dsp.LastTrigger = math.MinInt64 / 4 // far in the past, but not so far we can't subtract from it
 	dsp.projectors.Reset()
 	dsp.basis.Reset()
+	dsp.triggerCounter = NewTriggerCounter(1000000000, time.Now().Nanosecond())
 	// dsp.basis has zero value
 	// dsp.projectors has zero value
 	return &dsp

--- a/process_data.go
+++ b/process_data.go
@@ -11,7 +11,7 @@ import (
 
 // DataStreamProcessor contains all the state needed to decimate, trigger, write, and publish data.
 type DataStreamProcessor struct {
-	Channum              int
+	channelIndex         int
 	Name                 string
 	Broker               *TriggerBroker
 	NSamples             int
@@ -70,13 +70,12 @@ func NewDataStreamProcessor(chnum int, broker *TriggerBroker) *DataStreamProcess
 	stream := NewDataStream(data, framesPerSample, firstFrame, firstTime, period)
 	nsamp := 1024 // TODO: figure out what this ought to be, or make an argument
 	npre := 256   // TODO: figure out what this ought to be, or make an argument
-	dsp := DataStreamProcessor{Channum: chnum, Broker: broker,
+	dsp := DataStreamProcessor{channelIndex: chnum, Broker: broker,
 		stream: *stream, NSamples: nsamp, NPresamples: npre,
 	}
 	dsp.LastTrigger = math.MinInt64 / 4 // far in the past, but not so far we can't subtract from it
 	dsp.projectors.Reset()
 	dsp.basis.Reset()
-	dsp.triggerCounter = NewTriggerCounter(1000000000, time.Now().Nanosecond())
 	// dsp.basis has zero value
 	// dsp.projectors has zero value
 	return &dsp

--- a/publish_data.go
+++ b/publish_data.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"reflect"
+	"time"
 	"unsafe"
 
 	"github.com/usnistgov/dastard/getbytes"
@@ -19,6 +20,7 @@ type DataPublisher struct {
 	PubSummariesChan chan []*DataRecord
 	LJH22            *ljh.Writer
 	LJH3             *ljh.Writer3
+	triggerCounter   TriggerCounter
 }
 
 // SetLJH3 adds an LJH3 writer to dp, the .file attribute is nil, and will be instantiated upon next call to dp.WriteRecord
@@ -148,6 +150,10 @@ func (dp DataPublisher) PublishData(records []*DataRecord) error {
 			dp.LJH3.WriteRecord(int32(record.presamples+1), int64(record.trigFrame), int64(nano)/1000, rawTypeToUint16(record.data))
 		}
 	}
+	for _, record := range records {
+		dp.triggerCounter.Observe(record.trigTime.Nanosecond())
+	}
+	dp.triggerCounter.ObserveTime()
 	return nil
 }
 
@@ -160,6 +166,7 @@ func (dp DataPublisher) PublishData(records []*DataRecord) error {
 // float32: pretrigMean
 // float32: peakValue
 // float32: pulseRMS
+// float32: pulseAverage
 // float32: residualStdDev
 // uint64: UnixNano trigTime
 // uint64: trigFrame
@@ -300,4 +307,53 @@ func bytesToRawType(b []byte) []RawType {
 	header.Len /= ratio
 	data := *(*[]RawType)(unsafe.Pointer(&header))
 	return data
+}
+
+// TriggerCounter counts triggers
+type TriggerCounter struct {
+	nanoStep   int
+	nanoHi     int
+	nanoLo     int
+	countsSeen int
+}
+
+// NewTriggerCounter returns a TriggerCounter
+// nanoNow should be the current time in nanoSeconds, but is passed
+// as an argument to make sure many new trigger Brokers get the same value
+func NewTriggerCounter(nanoStep int, nanoNow int) TriggerCounter {
+	nanoHi := (nanoNow / nanoStep) * nanoNow
+	return TriggerCounter{nanoStep: nanoStep, nanoHi: nanoHi, nanoLo: nanoHi - nanoStep}
+}
+
+func (tc *TriggerCounter) messageAndReset() {
+	fmt.Printf("%v counts seen in %v nanosecond period ending at %v\n", tc.countsSeen,
+		tc.nanoStep, tc.nanoHi)
+	tc.countsSeen = 0
+	tc.nanoHi += tc.nanoStep
+	tc.nanoLo = tc.nanoHi - tc.nanoStep
+}
+
+// Observe a single trigger at nano (a unix time in nanoseconds)
+// possibly create a message, increment countSeen, check for out of bounds errors
+func (tc *TriggerCounter) Observe(nano int) error {
+	for nano > tc.nanoHi {
+		tc.messageAndReset()
+	}
+	if nano <= tc.nanoLo {
+		return fmt.Errorf("observed count before nanoLo=%v, nano=%v", tc.nanoLo, nano)
+	}
+	tc.countsSeen += 1
+	return nil
+}
+
+// ObserveTime the current time, possibly create messages
+func (tc *TriggerCounter) ObserveTime() error {
+	nano := time.Now().Nanosecond()
+	for nano > tc.nanoHi {
+		tc.messageAndReset()
+	}
+	if nano <= tc.nanoLo {
+		return fmt.Errorf("observed time before nanoLo=%v, nano=%v", tc.nanoLo, nano)
+	}
+	return nil
 }

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -341,12 +341,12 @@ func (s *SourceControl) SendAllStatus(dummy *string, reply *bool) error {
 }
 
 // RunRPCServer sets up and run a permanent JSON-RPC server.
-func RunRPCServer(messageChan chan<- ClientUpdate, portrpc int) {
+func RunRPCServer(portrpc int) {
 
 	// Set up objects to handle remote calls
 	sourceControl := NewSourceControl()
 	defer sourceControl.lancero.Delete()
-	sourceControl.clientUpdates = messageChan
+	sourceControl.clientUpdates = clientMessageChan
 
 	// Load stored settings, and transfer saved configuration
 	// from Viper to relevant objects.

--- a/rpc_server_test.go
+++ b/rpc_server_test.go
@@ -306,9 +306,8 @@ func TestMain(m *testing.M) {
 	}
 
 	// call flag.Parse() here if TestMain uses flags
-	messageChan := make(chan ClientUpdate)
-	go RunClientUpdater(messageChan, Ports.Status)
-	go RunRPCServer(messageChan, Ports.RPC)
+	go RunClientUpdater(Ports.Status)
+	go RunRPCServer(Ports.RPC)
 	// set log to write to a file
 	f, err := os.Create("dastardtestlogfile")
 	if err != nil {


### PR DESCRIPTION
* dastard publishes trigger rate messages on the client update socket with tag "TRIGGERRATE". 
* publishes every second, but is easy to change if needed. 
* moved the `clientMessageChan` to a global variable.
* the logic exists in `group_trigger.go` because it helps to have all the channels syncd. 
* used `channelIndex` name everywhere I touched
* I tested with cmd/dastard and it seems to work. The trigger rate from auto-trigger is not actually constant, so I think there is a bug in auto trigger. I confirmed that it's actually the trigger rate and not the trigger rate counting code by looking at the time seperation between triggers in python.