### PR TITLE
Signed error data channels are handled properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ lancero/acquire/acquire
 dastardtestlogfile
 *.ljh
 *.ljh3
+dastard

--- a/BINARY_FORMATS.md
+++ b/BINARY_FORMATS.md
@@ -27,12 +27,12 @@ The header also contains little-endian values:
 Because the channel number makes up the first 2 bytes, ZMQ subscriber sockets can
 subscribe selectively to only certain channels.
 
-Data type code:
+Data type code: so far, only uint16 and int16 are allowed.
 
 * 0 = int8
 * 1 = uint8
 * 2 = int16
-* 3 = uint16 (*so far, only this type is allowed*)
+* 3 = uint16
 * 4 = int32
 * 5 = uint32
 * 6 = int64

--- a/data_source.go
+++ b/data_source.go
@@ -90,7 +90,8 @@ func Start(ds DataSource) error {
 type AnySource struct {
 	nchan        int      // how many channels to provide
 	chanNames    []string // one name per channel
-	sampleRate   float64  // samples per second
+	signed       []bool
+	sampleRate   float64 // samples per second
 	lastread     time.Time
 	nextFrameNum FrameIndex // frame number for the next frame we will receive
 	output       []chan DataSegment
@@ -240,7 +241,10 @@ func (ds *AnySource) Running() bool {
 
 // Signed returns a per-channel value: whether data are signed ints.
 func (ds *AnySource) Signed() []bool {
-	return make([]bool, ds.nchan)
+	if ds.signed == nil {
+		ds.signed = make([]bool, ds.nchan)
+	}
+	return ds.signed
 }
 
 // VoltsPerArb returns a per-channel value scaling raw into volts.

--- a/data_source.go
+++ b/data_source.go
@@ -30,6 +30,8 @@ type DataSource interface {
 	Outputs() []chan DataSegment
 	CloseOutputs()
 	Nchan() int
+	Signed() []bool
+	VoltsPerArb() []float32
 	ComputeFullTriggerState() []FullTriggerState
 	ComputeWritingState() WritingState
 	ChannelNames() []string
@@ -236,6 +238,20 @@ func (ds *AnySource) Running() bool {
 	}
 }
 
+// Signed returns a per-channel value: whether data are signed ints.
+func (ds *AnySource) Signed() []bool {
+	return make([]bool, ds.nchan)
+}
+
+// VoltsPerArb returns a per-channel value scaling raw into volts.
+func (ds *AnySource) VoltsPerArb() []float32 {
+	v := make([]float32, ds.nchan)
+	for i := 0; i < ds.nchan; i++ {
+		v[i] = 1. / 65535.0
+	}
+	return v
+}
+
 // setDefaultChannelNames defensively sets channel names of the appropriate length.
 // They should have been set in DataSource.Sample()
 func (ds *AnySource) setDefaultChannelNames() {
@@ -274,10 +290,14 @@ func (ds *AnySource) PrepareRun() error {
 	// Launch goroutines to drain the data produced by this source
 	ds.processors = make([]*DataStreamProcessor, ds.nchan)
 	ds.runDone.Add(ds.nchan)
+	signed := ds.Signed()
+	vpa := ds.VoltsPerArb()
 	for channelNum, dataSegmentChan := range ds.output {
 		dsp := NewDataStreamProcessor(channelNum, ds.broker)
 		dsp.Name = ds.chanNames[channelNum]
 		dsp.SampleRate = ds.sampleRate
+		dsp.stream.signed = signed[channelNum]
+		dsp.stream.voltsPerArb = vpa[channelNum]
 		ds.processors[channelNum] = dsp
 
 		// TODO: don't just set these to arbitrary values
@@ -398,11 +418,12 @@ func (ds *AnySource) ConfigurePulseLengths(nsamp, npre int) error {
 // raw-physical units, first sample’s frame number and sample time. Not yet triggered.
 type DataSegment struct {
 	rawData         []RawType
+	signed          bool
 	framesPerSample int // Normally 1, but can be larger if decimated
 	firstFramenum   FrameIndex
 	firstTime       time.Time
 	framePeriod     time.Duration
-	// something about raw-physical conversion???
+	voltsPerArb     float32
 	// facts about the data source?
 }
 
@@ -467,8 +488,10 @@ type DataRecord struct {
 	data         []RawType
 	trigFrame    FrameIndex
 	trigTime     time.Time
+	signed       bool // do we interpret the data as signed values?
 	channelIndex int
 	presamples   int
+	voltsPerArb  float32 // "volts" or other physical unit per raw unit
 	sampPeriod   float32
 
 	// trigger type?

--- a/data_source_test.go
+++ b/data_source_test.go
@@ -85,3 +85,23 @@ func TestWritingFiles(t *testing.T) {
 		}
 	}
 }
+
+func TestDataScaling(t *testing.T) {
+	var ts TriangleSource
+	ts.nchan = 4
+	st := ts.Signed()
+	for i, s := range st {
+		if s {
+			t.Errorf("TriangleSource.Signed()[%d] is true, want false", i)
+		}
+	}
+	var ls LanceroSource
+	ls.nchan = 4
+	st = ls.Signed()
+	for i, s := range st {
+		expect := (i % 2) == 0
+		if s != expect {
+			t.Errorf("LanceroSource.Signed()[%d] is %t, want %t", i, s, expect)
+		}
+	}
+}

--- a/data_source_test.go
+++ b/data_source_test.go
@@ -85,23 +85,3 @@ func TestWritingFiles(t *testing.T) {
 		}
 	}
 }
-
-func TestDataScaling(t *testing.T) {
-	var ts TriangleSource
-	ts.nchan = 4
-	st := ts.Signed()
-	for i, s := range st {
-		if s {
-			t.Errorf("TriangleSource.Signed()[%d] is true, want false", i)
-		}
-	}
-	var ls LanceroSource
-	ls.nchan = 4
-	st = ls.Signed()
-	for i, s := range st {
-		expect := (i % 2) == 0
-		if s != expect {
-			t.Errorf("LanceroSource.Signed()[%d] is %t, want %t", i, s, expect)
-		}
-	}
-}

--- a/lancero_source.go
+++ b/lancero_source.go
@@ -491,3 +491,25 @@ func (ls *LanceroSource) stop() error {
 	}
 	return nil
 }
+
+// Signed returns a per-channel value: whether data are signed ints.
+func (ls *LanceroSource) Signed() []bool {
+	s := make([]bool, ls.nchan)
+	for i := 0; i < ls.nchan; i += 2 {
+		s[i] = true
+	}
+	return s
+}
+
+// VoltsPerArb returns a per-channel value scaling raw into volts.
+func (ls *LanceroSource) VoltsPerArb() []float32 {
+	const Nsamp float32 = 4.0 // TODO: what is Nsamp? 4 is typical but not guaranteed.
+	v := make([]float32, ls.nchan)
+	for i := 0; i < ls.nchan; i += 2 {
+		v[i] = 1.0 / (4096. * Nsamp)
+	}
+	for i := 1; i < ls.nchan; i += 2 {
+		v[i] = 1. / 65535.0
+	}
+	return v
+}

--- a/lancero_source.go
+++ b/lancero_source.go
@@ -383,11 +383,6 @@ func (ls *LanceroSource) distributeData(timestamp time.Time, wait time.Duration)
 		if bframes < framesUsed {
 			framesUsed = bframes
 		}
-		// rate := 0.0
-		// if wait > 0 {
-		// 	rate = float64(len(b)) * 1e3 / float64(wait)
-		// }
-		// fmt.Printf("new buffer of length %8d b after wait %6.2f ms for %8.2f Mb/s\n", len(b), .001*float64(wait/time.Microsecond), rate)
 	}
 	if framesUsed <= 0 {
 		fmt.Printf("Nothing to consume, buffer[0] size: %d samples\n", len(buffers[0]))
@@ -430,10 +425,9 @@ func (ls *LanceroSource) distributeData(timestamp time.Time, wait time.Duration)
 			mix.MixRetardFb(&data, &errData)
 			// MixRetardFb alters data in place to mix some of errData in based on mix.mixFraction
 		}
-		// TODO: replace framesPerSample=1 with the actual decimation level
 		seg := DataSegment{
 			rawData:         data,
-			framesPerSample: 1,
+			framesPerSample: 1, // This will be changed later if decimating
 			firstFramenum:   ls.nextFrameNum,
 			firstTime:       firstTime,
 		}

--- a/lancero_source.go
+++ b/lancero_source.go
@@ -158,6 +158,10 @@ func (ls *LanceroSource) Sample() error {
 	}
 	ls.updateChanOrderMap()
 
+	ls.signed = make([]bool, ls.nchan)
+	for i := 0; i < ls.nchan; i += 2 {
+		ls.signed[i] = true
+	}
 	ls.chanNames = make([]string, ls.nchan)
 	for i := 1; i < ls.nchan; i += 2 {
 		ls.chanNames[i-1] = fmt.Sprintf("err%d", 1+i/2)
@@ -464,15 +468,6 @@ func (ls *LanceroSource) stop() error {
 		}
 	}
 	return nil
-}
-
-// Signed returns a per-channel value: whether data are signed ints.
-func (ls *LanceroSource) Signed() []bool {
-	s := make([]bool, ls.nchan)
-	for i := 0; i < ls.nchan; i += 2 {
-		s[i] = true
-	}
-	return s
 }
 
 // VoltsPerArb returns a per-channel value scaling raw into volts.

--- a/lancero_test.go
+++ b/lancero_test.go
@@ -130,7 +130,19 @@ func TestMix(t *testing.T) {
 		}
 	}
 	if !passed {
-		t.Errorf("want all zeros, have\n%v", data)
+		t.Errorf("have %v, want all zeros", data)
 	}
 
+	// Check that overflows are clamped to proper range
+	err1 := []RawType{100, 0, 65436} // {100, 0, -100} as signed ints
+	mix = Mix{mixFraction: 1.0}
+	mix.lastFb = 65530
+	fb := []RawType{0, 50, 50}
+	expect = []RawType{65535, 0, 0}
+	mix.MixRetardFb(&fb, &err1)
+	for i, e := range expect {
+		if fb[i] != e {
+			t.Errorf("mix with overflows fb[%d]=%d, want %d", i, fb[i], e)
+		}
+	}
 }

--- a/process_data.go
+++ b/process_data.go
@@ -137,21 +137,39 @@ func (dsp *DataStreamProcessor) DecimateData(segment *DataSegment) {
 	Nout := (Nin - 1 + dsp.DecimateLevel) / dsp.DecimateLevel
 	if dsp.DecimateAvgMode {
 		level := dsp.DecimateLevel
-		for i := 0; i < Nout-1; i++ {
-			val := float64(data[i*level])
-			for j := 1; j < level; j++ {
-				val += float64(data[j+i*level])
+		cdata := make([]float64, Nout)
+		if segment.signed {
+			for i := 0; i < Nin; i++ {
+				j := i / level
+				cdata[j] += float64(int16(data[i]))
 			}
-			data[i] = RawType(val/float64(level) + 0.5)
+		} else {
+			for i := 0; i < Nin; i++ {
+				j := i / level
+				cdata[j] += float64(data[i])
+			}
 		}
-		val := float64(data[(Nout-1)*level])
-		count := 1.0
-		for j := (Nout-1)*level + 1; j < Nin; j++ {
-			val += float64(data[j])
-			count++
+		if Nout*dsp.DecimateLevel < Nin {
+			extra := Nin % level
+			cdata[Nout-1] *= float64(level) / float64(extra)
 		}
-		data[Nout-1] = RawType(val/count + 0.5)
+
+		if segment.signed {
+			for i := 0; i < Nout; i++ {
+				// Trick for rounding to int16: don't let any numbers be negative
+				// because float->int is a truncation operation. If we remove the
+				// +65536 below, then 0 will be a "rounding attractor".
+				data[i] = RawType(int16(cdata[i]/float64(level) + 65536 + 0.5))
+			}
+
+		} else {
+			for i := 0; i < Nout; i++ {
+				data[i] = RawType(cdata[i]/float64(level) + 0.5)
+			}
+		}
+
 	} else {
+		// Decimate by dropping data
 		for i := 0; i < Nout; i++ {
 			data[i] = data[i*dsp.DecimateLevel]
 		}

--- a/process_data.go
+++ b/process_data.go
@@ -123,8 +123,7 @@ func (dsp *DataStreamProcessor) processSegment(segment *DataSegment) {
 	dsp.stream.AppendSegment(segment)
 	// records, secondaries := dsp.TriggerData()
 	records, _ := dsp.TriggerData()
-	dsp.AnalyzeData(records) // add analysis results to records in-place
-	// TODO: dsp.WriteData(records)
+	dsp.AnalyzeData(records)               // add analysis results to records in-place
 	dsp.DataPublisher.PublishData(records) // publish and save data, when enabled
 }
 

--- a/process_data_test.go
+++ b/process_data_test.go
@@ -179,34 +179,25 @@ func testAnalyzeCheck(t *testing.T, rec *DataRecord, expect RTExpect, name strin
 }
 
 func TestDataSignedness(t *testing.T) {
+	// Make sure PrepareRun produces the right answers.
 	var ts TriangleSource
 	ts.nchan = 4
-	st := ts.Signed()
-	for i, s := range st {
-		if s {
-			t.Errorf("TriangleSource.Signed()[%d] is true, want false", i)
+	ts.PrepareRun()
+	for i, dsp := range ts.processors {
+		expect := false
+		if dsp.stream.signed != expect {
+			t.Errorf("LanceroSource.processors[%d].stream.signed is %t, want %t", i, dsp.stream.signed, expect)
 		}
 	}
+
+	// TODO: use a no-hardware source to test this!
 	var ls LanceroSource
 	ls.nchan = 4
-	st = ls.Signed()
-	for i, s := range st {
-		expect := (i % 2) == 0
-		if s != expect {
-			t.Errorf("LanceroSource.Signed()[%d] is %t, want %t", i, s, expect)
-		}
+	ls.signed = make([]bool, ls.nchan)
+	for i := 0; i < ls.nchan; i += 2 {
+		ls.signed[i] = true
 	}
-	// Make sure it works even when you hold the LanceroSource by its interface.
-	ds := DataSource(&ls)
-	st = ds.Signed()
-	for i, s := range st {
-		expect := (i % 2) == 0
-		if s != expect {
-			t.Errorf("DataSource(*LanceroSource).Signed()[%d] is %t, want %t", i, s, expect)
-		}
-	}
-	// Make sure it works when you run PrepareRun.
-	ds.PrepareRun()
+	ls.PrepareRun()
 	for i, dsp := range ls.processors {
 		expect := (i % 2) == 0
 		if dsp.stream.signed != expect {

--- a/process_data_test.go
+++ b/process_data_test.go
@@ -196,6 +196,23 @@ func TestDataSignedness(t *testing.T) {
 			t.Errorf("LanceroSource.Signed()[%d] is %t, want %t", i, s, expect)
 		}
 	}
+	// Make sure it works even when you hold the LanceroSource by its interface.
+	ds := DataSource(&ls)
+	st = ds.Signed()
+	for i, s := range st {
+		expect := (i % 2) == 0
+		if s != expect {
+			t.Errorf("DataSource(*LanceroSource).Signed()[%d] is %t, want %t", i, s, expect)
+		}
+	}
+	// Make sure it works when you run PrepareRun.
+	ds.PrepareRun()
+	for i, dsp := range ls.processors {
+		expect := (i % 2) == 0
+		if dsp.stream.signed != expect {
+			t.Errorf("LanceroSource.processors[%d].stream.signed is %t, want %t", i, dsp.stream.signed, expect)
+		}
+	}
 
 	errsig := []RawType{3, 3, 1, 1, 65535, 65535, 65533, 65533,
 		65533, 65535, 65535, 1, 1, 3, 65535, 1, 65530, 6, 65500, 36}

--- a/publish_data.go
+++ b/publish_data.go
@@ -201,15 +201,18 @@ func messageSummaries(rec *DataRecord) [][]byte {
 // uint32: # of pre-trigger samples
 // uint32: # of samples, total
 // float32: sample period, in seconds (float)
-// float32: volts per arb conversion (float) (not implemented yet)
+// float32: volts per arb conversion (float)
 // uint64: trigger time, in ns since epoch 1970
 // uint64: trigger frame #
 // end of first message packet
-// data, each sample is uint16, length can vary (but for now is equal to # of samples which should be removed because it is redundant)
+// data, each sample is uint16, length given above
 func messageRecords(rec *DataRecord) [][]byte {
 
 	const headerVersion = uint8(0)
-	const dataType = uint8(3)
+	dataType := uint8(3)
+	if rec.signed {
+		dataType--
+	}
 	header := new(bytes.Buffer)
 	header.Write(getbytes.FromUint16(uint16(rec.channelIndex)))
 	header.Write(getbytes.FromUint8(headerVersion))
@@ -217,7 +220,7 @@ func messageRecords(rec *DataRecord) [][]byte {
 	header.Write(getbytes.FromUint32(uint32(rec.presamples)))
 	header.Write(getbytes.FromUint32(uint32(len(rec.data))))
 	header.Write(getbytes.FromFloat32(rec.sampPeriod))
-	header.Write(getbytes.FromFloat32(0)) // todo make this meaningful, though doesn't seem like its needed with every pulse
+	header.Write(getbytes.FromFloat32(rec.voltsPerArb))
 	nano := rec.trigTime.UnixNano()
 	header.Write(getbytes.FromInt64(nano))
 	header.Write(getbytes.FromUint64(uint64(rec.trigFrame)))

--- a/publish_data_test.go
+++ b/publish_data_test.go
@@ -85,6 +85,20 @@ func TestPublishData(t *testing.T) {
 	if err := configurePubSummariesSocket(); err == nil {
 		t.Error("it should be an error to configurePubSummariesSocket twice")
 	}
+
+	for i, signed := range []bool{false, true} {
+		(*rec).signed = signed
+		msg := messageRecords(rec)
+		header := msg[0]
+		dtype := header[3]
+		expect := []uint8{3, 2}
+		if dtype != expect[i] {
+			t.Errorf("messageRecords with signed=%t gives dtype=%d, want %d",
+				signed, dtype, expect[i])
+		}
+
+	}
+
 }
 
 func TestRawTypeToX(t *testing.T) {

--- a/segment_test.go
+++ b/segment_test.go
@@ -181,7 +181,7 @@ func TestDecimation(t *testing.T) {
 			ch.DecimateAvgMode = useAvg
 			dcopy := make([]RawType, N)
 			copy(dcopy, data)
-			seg := &DataSegment{rawData: dcopy, framesPerSample: 1}
+			seg := &DataSegment{rawData: dcopy, framesPerSample: 1, signed: false}
 			ch.DecimateData(seg)
 			if seg.framesPerSample != decimation {
 				t.Errorf("DataChannel.DecimateData did not alter framesPerSample = %d, want %d",

--- a/simulated_data_sources.go
+++ b/simulated_data_sources.go
@@ -59,6 +59,7 @@ func (ts *TriangleSource) Configure(config *TriangleSourceConfig) error {
 // It's a no-op for simulated (software) sources
 func (ts *TriangleSource) Sample() error {
 	ts.chanNames = make([]string, ts.nchan)
+	ts.signed = make([]bool, ts.nchan)
 	for i := 0; i < ts.nchan; i++ {
 		ts.chanNames[i] = fmt.Sprintf("tri%d", i+1)
 	}
@@ -162,6 +163,7 @@ func (sps *SimPulseSource) Configure(config *SimPulseSourceConfig) error {
 // It's a no-op for simulated (software) sources
 func (sps *SimPulseSource) Sample() error {
 	sps.chanNames = make([]string, sps.nchan)
+	sps.signed = make([]bool, sps.nchan)
 	for i := 0; i < sps.nchan; i++ {
 		sps.chanNames[i] = fmt.Sprintf("sim%d", i+1)
 	}

--- a/triggering_test.go
+++ b/triggering_test.go
@@ -263,6 +263,31 @@ func TestSingles(t *testing.T) {
 		expected = append(expected, FrameIndex(i))
 	}
 	testTriggerSubroutine(t, raw, nRepeat, dsp, "AutoMultipleSegmentsB", expected)
+
+	// Test signed signals
+	for i := 0; i < len(raw); i++ {
+		raw[i] = 65530
+	}
+	for i := tframe; i < tframe+10; i++ {
+		raw[i] = bigval
+	}
+	for i := tframe2; i < tframe2+10; i++ {
+		raw[i] = smallval
+	}
+	nRepeat = 1
+	dsp.stream.signed = true
+	dsp.LevelTrigger = false
+	dsp.AutoTrigger = false
+	dsp.EdgeTrigger = true
+	dsp.EdgeRising = true
+	dsp.EdgeLevel = 100
+	testTriggerSubroutine(t, raw, nRepeat, dsp, "Edge signed", []FrameIndex{1000})
+
+	dsp.EdgeTrigger = false
+	dsp.LevelTrigger = true
+	dsp.LevelRising = true
+	dsp.LevelLevel = 100
+	testTriggerSubroutine(t, raw, nRepeat, dsp, "Level signed", []FrameIndex{1000})
 }
 
 func testTriggerSubroutine(t *testing.T, raw []RawType, nRepeat int, dsp *DataStreamProcessor,


### PR DESCRIPTION
This is to properly handle the fact that some channels use `RawType` (`uint16`) for the data, but the actual contents are signed `int16` values. This must be considered in computing several things. From more to less important:

- Mixing of error into FB
- Triggers
- Decimated data streams (if you're using the averaging method)
- `AnalyzeData` analysis values like pulse average and RMS

It might be that the analysis values for error channels in the TDM system are meaningless, but the mixing is important, and triggering can be, too.

I believe this PR includes tests for all the new features, tests of mix, triggering, decimation, and analysis that would all have failed before these changes.