### PR TITLE
Dastard tracks NSAMP and weights mix fraction appropriately

### DIFF
--- a/lancero_source.go
+++ b/lancero_source.go
@@ -130,13 +130,11 @@ func (ls *LanceroSource) Configure(config *LanceroSourceConfig) error {
 	}
 	sort.Ints(config.AvailableCards)
 
-	// Ignore nsamp if not positive
-	if config.Nsamp > 16 {
-		return fmt.Errorf("LanceroSourceConfig.Nsamp=%d but requires NSAMP<=16", config.Nsamp)
+	// Error if Nsamp not in [1,16].
+	if config.Nsamp > 16 || config.Nsamp < 1 {
+		return fmt.Errorf("LanceroSourceConfig.Nsamp=%d but requires 1<=NSAMP<=16", config.Nsamp)
 	}
-	if config.Nsamp > 0 {
-		ls.nsamp = config.Nsamp
-	}
+	ls.nsamp = config.Nsamp
 	return nil
 }
 

--- a/lancero_source.go
+++ b/lancero_source.go
@@ -104,6 +104,9 @@ type LanceroSourceConfig struct {
 // ActiveCards is a slice of indicies into ls.devices to activate
 // AvailableCards is an output, contains a sorted slice of valid indicies for use in ActiveCards
 func (ls *LanceroSource) Configure(config *LanceroSourceConfig) error {
+	ls.runMutex.Lock()
+	defer ls.runMutex.Unlock()
+
 	ls.active = make([]*LanceroDevice, 0)
 	ls.clockMhz = config.ClockMhz
 	for i, c := range config.ActiveCards {
@@ -178,7 +181,7 @@ func (ls *LanceroSource) ConfigureMixFraction(processorIndex int, mixFraction fl
 	go func() {
 		ls.runMutex.Lock()
 		defer ls.runMutex.Unlock()
-		ls.Mix[processorIndex].mixFraction = mixFraction
+		ls.Mix[processorIndex].mixFraction = mixFraction / float64(ls.nsamp)
 	}()
 	return nil
 }

--- a/lancero_source.go
+++ b/lancero_source.go
@@ -202,7 +202,7 @@ func (ls *LanceroSource) Sample() error {
 	}
 	ls.voltsPerArb = make([]float32, ls.nchan)
 	for i := 0; i < ls.nchan; i += 2 {
-		ls.voltsPerArb[i] = 1.0 / (4096. * ls.nsamp)
+		ls.voltsPerArb[i] = 1.0 / (4096. * float32(ls.nsamp))
 	}
 	for i := 1; i < ls.nchan; i += 2 {
 		ls.voltsPerArb[i] = 1. / 65535.0

--- a/lancero_test.go
+++ b/lancero_test.go
@@ -107,8 +107,16 @@ func TestNoHardwareSource(t *testing.T) {
 	}
 	for i := 0; i < nLancero; i++ {
 		if config.ActiveCards[i] != config.AvailableCards[i] {
-			t.Errorf("AvailableCards not populated corrects. AvailableCards %v", config.AvailableCards)
+			t.Errorf("AvailableCards not populated correctly. AvailableCards %v", config.AvailableCards)
 		}
+	}
+	config.Nsamp = 499
+	if err := source.Configure(&config); err == nil {
+		t.Error("LanceroSource.Configure should fail with Nsamp>16")
+	}
+	config.Nsamp = 4
+	if err := source.Configure(&config); err != nil {
+		t.Error("LanceroSource.Configure fails:", err)
 	}
 
 	if err := Start(source); err != nil {

--- a/lancero_test.go
+++ b/lancero_test.go
@@ -101,7 +101,7 @@ func TestNoHardwareSource(t *testing.T) {
 		t.Error("expected error for re-using a device")
 	}
 	config = LanceroSourceConfig{ClockMhz: 125, CardDelay: cardDelay,
-		ActiveCards: activeCards}
+		ActiveCards: activeCards, Nsamp: 1}
 	if err := source.Configure(&config); err != nil {
 		t.Error(err)
 	}
@@ -143,7 +143,7 @@ func TestMix(t *testing.T) {
 		errData[i] = RawType(i * 4)
 
 	}
-	mix := Mix{mixFraction: 0}
+	mix := Mix{errorScale: 0}
 	mix.MixRetardFb(&data, &errData)
 	passed := true
 	for i := range data {
@@ -154,7 +154,7 @@ func TestMix(t *testing.T) {
 	if !passed {
 		t.Errorf("want all zeros, have\n%v", data)
 	}
-	mix = Mix{mixFraction: 1}
+	mix = Mix{errorScale: 1}
 	mix.MixRetardFb(&data, &errData)
 	passed = true
 	for i := range data {
@@ -188,7 +188,7 @@ func TestMix(t *testing.T) {
 	for i := range data {
 		data[i] = RawType(i % 4)
 	}
-	mix = Mix{mixFraction: 0}
+	mix = Mix{errorScale: 0}
 	mix.MixRetardFb(&data, &errData)
 	passed = true
 	for i := range data {
@@ -202,7 +202,7 @@ func TestMix(t *testing.T) {
 
 	// Check that overflows are clamped to proper range
 	err1 := []RawType{100, 0, 65436} // {100, 0, -100} as signed ints
-	mix = Mix{mixFraction: 1.0}
+	mix = Mix{errorScale: 1.0}
 	mix.lastFb = 65530
 	fb := []RawType{0, 50, 50}
 	expect = []RawType{65535, 0, 0}

--- a/mix.go
+++ b/mix.go
@@ -4,26 +4,34 @@ import (
 	"math"
 )
 
-// Mix performns the mix for lancero data, handles retarding on datastream
-// Retard the raw data stream by 1 sample so it can be mixed with
+// Mix performns the mix for lancero data and retards the raw data stream by
+// one sample so it can be mixed with the appropriate error sample. This corrects
+// for a poor choice in the TDM firmware design, but so it goes.
 //
-// the appropriate error sample. This corrects for a poor choice in the
-// TDM firmware design, but so it goes.
 // fb_physical[n] refers to the feedback signal applied during tick [n]
-// err_physical[n] refers to the error signal measured during tick [n], eg with fb_physical[n] applied
-// fb_data[n]=fb_physical[n+1]
-// err_data[n]=err_physical[n]
-// in words: at frame [n] we get data for the error measured at frame [n]
-// and the feedback that will be applied during frame [n+1]
-// we want
-// mix[n] = fb_physical[n] + mixFraction * err_physical[n]
-// so
-// mix[n] = fb_data[n-1]   + mixFraction * err_data[n]
-// or
-// mix[n+1] = fb_data[n]   + mixFraction * err_data[n+1]
+// err_physical[n] refers to the error signal measured during tick [n]
+//
+// Unfortunately, the data stream pairs them up differently:
+// fb_data[n] = fb_physical[n+1]
+// err_data[n] = err_physical[n]
+//
+// At frame [n] we get data for the error measured during frame [n]
+// and the feedback computed based on it, which is the feedback
+// that will be _applied_ during frame [n+1].
+//
+// We want
+// mix[n] = fb_physical[n] + errorScale * err_physical[n], so
+// mix[n] = fb_data[n-1]   + errorScale * err_data[n], or
+// mix[n+1] = fb_data[n]   + errorScale * err_data[n+1]
+//
+// Second issue: the error signal we work with is a sum of NSAMP samples from
+// the ADC, but autotune's values assume that we work with the _mean_ (because it
+// lets autotune communicate an NSAMP-agnostic value). So we store NOT the auto-
+// tune value but the value that actually multiplies the error sum.
+//
 type Mix struct {
-	mixFraction float64
-	lastFb      RawType
+	errorScale float64 // Multiply this by raw error data. NSAMP is scaled out.
+	lastFb     RawType
 }
 
 // MixRetardFb mixes err into fbs, alters fbs in place to contain the mixed values
@@ -32,7 +40,7 @@ type Mix struct {
 // TDM systems, at least, and that is the only source that uses Mix.
 func (m *Mix) MixRetardFb(fbs *[]RawType, errs *[]RawType) {
 	const mask = ^RawType(0x03)
-	if m.mixFraction == 0.0 {
+	if m.errorScale == 0.0 {
 		for j := 0; j < len(*fbs); j++ {
 			fb := m.lastFb
 			m.lastFb = (*fbs)[j] & mask
@@ -42,7 +50,7 @@ func (m *Mix) MixRetardFb(fbs *[]RawType, errs *[]RawType) {
 	}
 	for j := 0; j < len(*fbs); j++ {
 		fb := m.lastFb
-		mixAmount := float64(int16((*errs)[j])) * m.mixFraction
+		mixAmount := float64(int16((*errs)[j])) * m.errorScale
 		// Be careful not to overflow!
 		floatMixResult := mixAmount + float64(fb)
 		m.lastFb = (*fbs)[j] & mask

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -127,8 +127,10 @@ type MixFractionObject struct {
 }
 
 // ConfigureMixFraction sets the MixFraction for the channel associated with ProcessorIndex
-// mix = fb + mixFraction*err
-// NOTE: only supported by LanceroSource
+// mix = fb + mixFraction*err/Nsamp
+// This MixFractionObject contains mix fractions as reported by autotune, where error/Nsamp
+// is used. Thus, we will internally store not MixFraction, but errorScale := MixFraction/Nsamp.
+// NOTE: only supported by LanceroSource.
 func (s *SourceControl) ConfigureMixFraction(mfo *MixFractionObject, reply *bool) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
This PR will track the Lancero card's NSAMP. For now, the user has to configure this (presumably via dastard-commander), but eventually it can be done by Cringe making an RPC call.

* accept NSAMP as part of the Lancero source configuration and report same to other clients.
* compute the voltsPerArb item for error channels as 1.0 / (NSAMP*4096) because its the sum of NSAMP values from a 12-bit ADC.
* rescale the requested mix fraction by 1/NSAMP.

Ready to pull, I believe.