### PR TITLE
Trigger states: restore from config file

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,0 +1,8 @@
+## DASTARD Versions
+
+**0.0.1** July 2018.
+* Fix irregular data rates for simulated sources due to latencies.
+
+
+**0.0.0** Development through July 2018.  
+* Trying to build a working system.

--- a/data_source.go
+++ b/data_source.go
@@ -355,9 +355,16 @@ func (ds *AnySource) PrepareRun() error {
 	}
 	// Use defaultTS for any channels not in the stored state.
 	// This will be needed any time you have more channels than in the
-	// last saved configuration.
-	defaultTS := TriggerState{AutoDelay: 250 * time.Millisecond,
-		LevelLevel: 4000, EdgeLevel: 100, EdgeRising: true}
+	// last saved configuration. All trigger types are disabled.
+	defaultTS := TriggerState{
+		AutoTrigger:  false,
+		AutoDelay:    250 * time.Millisecond,
+		EdgeTrigger:  false,
+		EdgeLevel:    100,
+		EdgeRising:   true,
+		LevelTrigger: false,
+		LevelLevel:   4000,
+	}
 
 	for channelNum, dataSegmentChan := range ds.output {
 		dsp := NewDataStreamProcessor(channelNum, ds.broker)
@@ -373,10 +380,6 @@ func (ds *AnySource) PrepareRun() error {
 		}
 		dsp.TriggerState = *ts
 
-		// TODO: don't just set decimation and samples/presamples to arbitrary values
-		dsp.Decimate = false
-		dsp.DecimateLevel = 2
-		dsp.DecimateAvgMode = true
 		dsp.NPresamples = 250
 		dsp.NSamples = 1000
 

--- a/data_source.go
+++ b/data_source.go
@@ -353,7 +353,9 @@ func (ds *AnySource) PrepareRun() error {
 			}
 		}
 	}
-	// use defaultTS for any channels not in the stored state
+	// Use defaultTS for any channels not in the stored state.
+	// This will be needed any time you have more channels than in the
+	// last saved configuration.
 	defaultTS := TriggerState{AutoDelay: 250 * time.Millisecond,
 		LevelLevel: 4000, EdgeLevel: 100, EdgeRising: true}
 

--- a/data_source.go
+++ b/data_source.go
@@ -380,9 +380,6 @@ func (ds *AnySource) PrepareRun() error {
 		}
 		dsp.TriggerState = *ts
 
-		dsp.NPresamples = 250
-		dsp.NSamples = 1000
-
 		// TODO: don't automatically turn on all record publishing.
 		dsp.SetPubRecords()
 		dsp.SetPubSummaries()

--- a/data_source.go
+++ b/data_source.go
@@ -346,13 +346,14 @@ func (ds *AnySource) PrepareRun() error {
 		fts = []FullTriggerState{}
 	}
 	tsptrs := make([]*TriggerState, ds.nchan)
-	for _, ts := range fts {
+	for i, ts := range fts {
 		for _, chnum := range ts.ChanNumbers {
 			if chnum < ds.nchan {
-				tsptrs[chnum] = &(ts.TriggerState)
+				tsptrs[chnum] = &(fts[i].TriggerState)
 			}
 		}
 	}
+	// use defaultTS for any channels not in the stored state
 	defaultTS := TriggerState{AutoDelay: 250 * time.Millisecond,
 		LevelLevel: 4000, EdgeLevel: 100, EdgeRising: true}
 
@@ -364,11 +365,11 @@ func (ds *AnySource) PrepareRun() error {
 		dsp.stream.voltsPerArb = vpa[channelNum]
 		ds.processors[channelNum] = dsp
 
-		ts := defaultTS
-		if tsptrs[channelNum] != nil {
-			ts = *tsptrs[channelNum]
+		ts := tsptrs[channelNum]
+		if ts == nil {
+			ts = &defaultTS
 		}
-		dsp.TriggerState = ts
+		dsp.TriggerState = *ts
 
 		// TODO: don't just set decimation and samples/presamples to arbitrary values
 		dsp.Decimate = false

--- a/global_config.go
+++ b/global_config.go
@@ -35,7 +35,7 @@ type BuildInfo struct {
 
 // Build is a global holding compile-time information about the build
 var Build = BuildInfo{
-	Version: "0.0.0",
+	Version: "0.0.1",
 	Githash: "no git hash computed",
 	Date:    "no build date computed",
 }

--- a/lancero/lancero.go
+++ b/lancero/lancero.go
@@ -183,7 +183,7 @@ func FindFrameBits(b []byte) (int, int, int, error) {
 	return q / 4, p / 4, n, fmt.Errorf("b did not contain two frame starts")
 }
 
-// OdDashTX creates output like od -xt, used for debugging Lancero
+// OdDashTX creates output like od -tx4, used for debugging Lancero
 func OdDashTX(b []byte, maxLines int) string {
 	var lineBuffer, outBuffer bytes.Buffer
 	var line, lastLine string
@@ -192,7 +192,7 @@ func OdDashTX(b []byte, maxLines int) string {
 	outBuffer.WriteString(fmt.Sprintf("dumping %v bytes, output max lines %v\n", len(b), maxLines))
 	outBuffer.WriteString("L = least significant byte, M = most significant byte\n")
 	outBuffer.WriteString("framebit in fbkL\n")
-	outBuffer.WriteString("errLerrM fbkLfdbM errLerrM fbkLfdbM errLerrM fbkLfdbM errLerrM fbkLfdbM \n")
+	outBuffer.WriteString("fMfLeMeL fMfLeMeL fMfLeMeL fMfLeMeL fMfLeMeL fMfLeMeL fMfLeMeL fMfLeMeL \n")
 	outBuffer.WriteString("-------- -------- -------- -------- -------- -------- -------- -------- \n")
 	lines := 0
 	for i := 0; i+3 < len(b) && lines < maxLines; i += 4 {

--- a/lancero/lancero.go
+++ b/lancero/lancero.go
@@ -193,6 +193,7 @@ func OdDashTX(b []byte, maxLines int) string {
 	outBuffer.WriteString("L = least significant byte, M = most significant byte\n")
 	outBuffer.WriteString("framebit in fbkL\n")
 	outBuffer.WriteString("errLerrM fbkLfdbM errLerrM fbkLfdbM errLerrM fbkLfdbM errLerrM fbkLfdbM \n")
+	outBuffer.WriteString("-------- -------- -------- -------- -------- -------- -------- -------- \n")
 	lines := 0
 	for i := 0; i+3 < len(b) && lines < maxLines; i += 4 {
 		encoder.Write([]byte{b[i+3]})

--- a/lancero/lancero_test.go
+++ b/lancero/lancero_test.go
@@ -114,23 +114,26 @@ func testLanceroerSubroutine(lan Lanceroer, t *testing.T) (int, int, int, error)
 
 func TestOdDashTX(t *testing.T) {
 	b := make([]byte, 10000)
-	if s := OdDashTX(b, 15); len(s) != 281 {
-		t.Errorf("have %v\n\n WRONG LENGTH, have %v, want 281", s, len(s))
+	expect := 354
+	if s := OdDashTX(b, 15); len(s) != expect {
+		t.Errorf("have %v\n\n WRONG LENGTH, have %v, want %d", s, len(s), expect)
 	}
 	for i := range b {
 		b[i] = byte(i)
 	}
-	if s := OdDashTX(b, 15); len(s) != 1280 {
-		t.Errorf("have %v\n\n WRONG LENGTH, have %v, want 1280", s, len(s))
+	expect = 1353
+	if s := OdDashTX(b, 15); len(s) != expect {
+		t.Errorf("have %v\n\n WRONG LENGTH, have %v, want %d", s, len(s), expect)
 	}
 	b = make([]byte, 0)
-	if s := OdDashTX(b, 15); len(s) != 181 {
-		t.Errorf("have %v\n\n WRONG LENGTH, have %v, want 181", s, len(s))
+	expect = 254
+	if s := OdDashTX(b, 15); len(s) != expect {
+		t.Errorf("have %v\n\n WRONG LENGTH, have %v, want %d", s, len(s), expect)
 	}
 	b = []byte{0xef, 0xbe, 0xad, 0xde, 0xef, 0xbe, 0xad, 0xde, 0xef, 0xbe, 0xad, 0xde, 0xef, 0xbe, 0xad, 0xde, 0xef, 0xbe, 0xad, 0xde, 0xef, 0xbe, 0xad, 0xde,
 		0xef, 0xbe, 0xad, 0xde, 0xef, 0xbe, 0xad, 0xde, 0xef, 0xbe, 0xad, 0xde, 0xef, 0xbe, 0xad, 0xde, 0xef, 0xbe, 0xad, 0xde, 0xef, 0xbe, 0xad, 0xde}
-	if s := OdDashTX(b, 15); strings.Compare("deadbeef", s[182:190]) != 0 {
-		t.Errorf("have %v, want %v", s[181:190], "deadbeef")
+	if s := OdDashTX(b, 15); strings.Compare("deadbeef", s[255:263]) != 0 {
+		t.Errorf("have %v, want %v", s[255:263], "deadbeef")
 	}
 }
 

--- a/rpc_server_test.go
+++ b/rpc_server_test.go
@@ -156,6 +156,11 @@ func TestServer(t *testing.T) {
 	time.Sleep(time.Millisecond * 400)
 	rows := 5
 	cols := 1000
+	size := SizeObject{Nsamp: cols, Npre: cols / 4}
+	err = client.Call("SourceControl.ConfigurePulseLengths", &size, &okay)
+	if err != nil {
+		t.Error(err)
+	}
 	projectors := mat.NewDense(rows, cols, make([]float64, rows*cols))
 	basis := mat.NewDense(cols, rows, make([]float64, rows*cols))
 	projectorsBytes, err := projectors.MarshalBinary()

--- a/triggering.go
+++ b/triggering.go
@@ -47,7 +47,6 @@ type TriggerState struct {
 	edgeMultiIPotential              FrameIndex
 	edgeMultiILastInspected          FrameIndex
 
-	// TODO:  Noise info.
 	// TODO: group source/rx info.
 }
 


### PR DESCRIPTION
The trigger state was being saved to the config file but not restored from it. This is now done, substituting sensible defaults (all trigger types off) for channels not in the saved state.

Fixes #58
