### PR TITLE
publish number of records written

### DIFF
--- a/client_updater.go
+++ b/client_updater.go
@@ -103,9 +103,10 @@ func RunClientUpdater(portstatus int) {
 // nosaveMessages is a set of message names that you don't save, because they
 // contain no configuration that makes sense to preserve across runs of dastard.
 var nosaveMessages = map[string]struct{}{
-	"channelnames": {},
-	"alive":        {},
-	"triggerrate":  {},
+	"channelnames":  {},
+	"alive":         {},
+	"triggerrate":   {},
+	"numberwritten": {},
 }
 
 // saveState stores server configuration to the standard config file.

--- a/group_trigger.go
+++ b/group_trigger.go
@@ -186,6 +186,7 @@ func (p FrameIdxSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 // Run runs in a goroutine to broker trigger frame #s from sources to receivers.
 // It runs in the pattern: get a message from each channel (about their triggered
 // frame numbers), then send a message to each channel (about their secondary triggers).
+// should be called in a goroutine
 func (broker *TriggerBroker) Run() {
 	for {
 		// get data from all PrimaryTrigs channels

--- a/process_data.go
+++ b/process_data.go
@@ -62,7 +62,7 @@ func (dsp *DataStreamProcessor) SetProjectorsBasis(projectors mat.Dense, basis m
 }
 
 // NewDataStreamProcessor creates and initializes a new DataStreamProcessor.
-func NewDataStreamProcessor(chnum int, broker *TriggerBroker) *DataStreamProcessor {
+func NewDataStreamProcessor(channelIndex int, broker *TriggerBroker, numberWrittenChan chan int) *DataStreamProcessor {
 	data := make([]RawType, 0, 1024)
 	framesPerSample := 1
 	firstFrame := FrameIndex(0)
@@ -71,9 +71,10 @@ func NewDataStreamProcessor(chnum int, broker *TriggerBroker) *DataStreamProcess
 	stream := NewDataStream(data, framesPerSample, firstFrame, firstTime, period)
 	nsamp := 1024 // TODO: figure out what this ought to be, or make an argument
 	npre := 256   // TODO: figure out what this ought to be, or make an argument
-	dsp := DataStreamProcessor{channelIndex: chnum, Broker: broker,
+	dsp := DataStreamProcessor{channelIndex: channelIndex, Broker: broker,
 		stream: *stream, NSamples: nsamp, NPresamples: npre,
 	}
+	dsp.DataPublisher.numberWrittenChan = numberWrittenChan
 	dsp.LastTrigger = math.MinInt64 / 4 // far in the past, but not so far we can't subtract from it
 	dsp.projectors.Reset()
 	dsp.basis.Reset()

--- a/process_data_test.go
+++ b/process_data_test.go
@@ -210,7 +210,7 @@ func TestDataSignedness(t *testing.T) {
 	data := make([]RawType, len(errsig))
 	copy(data, errsig)
 	seg := &DataSegment{rawData: data}
-	dsp := NewDataStreamProcessor(0, nil)
+	dsp := NewDataStreamProcessor(0, nil, nil)
 	dsp.DecimateLevel = 2
 	dsp.Decimate = true
 	dsp.DecimateAvgMode = true

--- a/publish_data_test.go
+++ b/publish_data_test.go
@@ -27,12 +27,18 @@ func TestPublishData(t *testing.T) {
 	if dp.LJH22.RecordsWritten != 3 {
 		t.Fail()
 	}
+	if dp.numberWritten != 3 {
+		t.Errorf("expected PublishData to increment numberWritten with LJH22 enabled")
+	}
 	if !dp.HasLJH22() {
 		t.Error("HasLJH22() false, want true")
 	}
 	dp.RemoveLJH22()
 	if dp.HasLJH22() {
 		t.Error("HasLJH22() true, want false")
+	}
+	if dp.numberWritten != 0 {
+		t.Errorf("expected RemoveLJH22 to set numberWritten to 0")
 	}
 
 	if dp.HasPubRecords() {
@@ -45,7 +51,9 @@ func TestPublishData(t *testing.T) {
 	}
 
 	dp.PublishData(records)
-
+	if dp.numberWritten != 0 {
+		t.Errorf("expected PublishData to not increment numberWritten with only PubRecords enabled")
+	}
 	dp.RemovePubRecords()
 	if dp.HasPubRecords() {
 		t.Error("HasPubRecords() true, want false")
@@ -74,10 +82,16 @@ func TestPublishData(t *testing.T) {
 	if dp.LJH3.RecordsWritten != 3 {
 		t.Error("wrong number of RecordsWritten, want 1, have", dp.LJH3.RecordsWritten)
 	}
+	if dp.numberWritten != 3 {
+		t.Errorf("expected PublishedData to increment numberWritten")
+	}
 	if !dp.HasLJH3() {
 		t.Error("HasLJH3() false, want true")
 	}
 	dp.RemoveLJH3()
+	if dp.numberWritten != 0 {
+		t.Errorf("expected RemoveLJH3 to set numberWritten to 0")
+	}
 	if dp.HasLJH3() {
 		t.Error("HasLJH3() true, want false")
 	}

--- a/triggering_test.go
+++ b/triggering_test.go
@@ -203,7 +203,7 @@ func TestLongRecords(t *testing.T) {
 		{1000, 10000, 10001},
 	}
 	for _, test := range tests {
-		dsp := NewDataStreamProcessor(0, broker)
+		dsp := NewDataStreamProcessor(0, broker, nil)
 		dsp.NPresamples = test.npre
 		dsp.NSamples = test.nsamp
 		dsp.SampleRate = 100000.0
@@ -246,7 +246,7 @@ func TestSingles(t *testing.T) {
 	broker := NewTriggerBroker(nchan)
 	go broker.Run()
 	defer broker.Stop()
-	dsp := NewDataStreamProcessor(0, broker)
+	dsp := NewDataStreamProcessor(0, broker, nil)
 	nRepeat := 1
 
 	const bigval = 8000
@@ -399,7 +399,7 @@ func TestEdgeLevelInteraction(t *testing.T) {
 	broker := NewTriggerBroker(nchan)
 	go broker.Run()
 	defer broker.Stop()
-	dsp := NewDataStreamProcessor(0, broker)
+	dsp := NewDataStreamProcessor(0, broker, nil)
 	nRepeat := 1
 
 	const bigval = 8000
@@ -457,7 +457,7 @@ func TestEdgeMulti(t *testing.T) {
 	broker := NewTriggerBroker(nchan)
 	go broker.Run()
 	defer broker.Stop()
-	dsp := NewDataStreamProcessor(0, broker)
+	dsp := NewDataStreamProcessor(0, broker, nil)
 	nRepeat := 1
 
 	//kink model parameters
@@ -558,7 +558,7 @@ func TestEdgeVetosLevel(t *testing.T) {
 	broker := NewTriggerBroker(nchan)
 	go broker.Run()
 	defer broker.Stop()
-	dsp := NewDataStreamProcessor(0, broker)
+	dsp := NewDataStreamProcessor(0, broker, nil)
 	dsp.NPresamples = 20
 	dsp.NSamples = 100
 
@@ -598,7 +598,7 @@ func BenchmarkAutoTriggerOpsAre100SampleTriggers(b *testing.B) {
 	broker := NewTriggerBroker(nchan)
 	go broker.Run()
 	defer broker.Stop()
-	dsp := NewDataStreamProcessor(0, broker)
+	dsp := NewDataStreamProcessor(0, broker, nil)
 	dsp.NPresamples = 20
 	dsp.NSamples = 100
 	dsp.AutoTrigger = true
@@ -622,7 +622,7 @@ func BenchmarkEdgeTrigger0TriggersOpsAreSamples(b *testing.B) {
 	broker := NewTriggerBroker(nchan)
 	go broker.Run()
 	defer broker.Stop()
-	dsp := NewDataStreamProcessor(0, broker)
+	dsp := NewDataStreamProcessor(0, broker, nil)
 	dsp.NPresamples = 20
 	dsp.NSamples = 100
 
@@ -655,7 +655,7 @@ func BenchmarkLevelTrigger0TriggersOpsAreSamples(b *testing.B) {
 	broker := NewTriggerBroker(nchan)
 	go broker.Run()
 	defer broker.Stop()
-	dsp := NewDataStreamProcessor(0, broker)
+	dsp := NewDataStreamProcessor(0, broker, nil)
 	dsp.NPresamples = 20
 	dsp.NSamples = 100
 


### PR DESCRIPTION
Uses a single counter for all types of records, resets the count any time any file writing is turned on or off.

This adds a 2nd synchronization point to dastard after record publication. The other is during group triggering.