### PR TITLE
Fix lancero timing

### DIFF
--- a/lancero/cmd/acquire/acquire.go
+++ b/lancero/cmd/acquire/acquire.go
@@ -199,7 +199,7 @@ func acquire(lan *lancero.Lancero) (bytesRead int, err error) {
 			if err != nil {
 				return
 			}
-			buffer, _, err = lan.AvailableBuffers()
+			buffer, _, err = lan.AvailableBuffer()
 			if opt.oddashtx {
 				fmt.Println(lancero.OdDashTX(buffer, 20))
 			}

--- a/lancero/cmd/acquire/acquire.go
+++ b/lancero/cmd/acquire/acquire.go
@@ -199,7 +199,7 @@ func acquire(lan *lancero.Lancero) (bytesRead int, err error) {
 			if err != nil {
 				return
 			}
-			buffer, err = lan.AvailableBuffers()
+			buffer, _, err = lan.AvailableBuffers()
 			if opt.oddashtx {
 				fmt.Println(lancero.OdDashTX(buffer, 20))
 			}

--- a/lancero/cmd/oddashtx/oddashtx.go
+++ b/lancero/cmd/oddashtx/oddashtx.go
@@ -55,7 +55,7 @@ func main() {
 			if err != nil {
 				return
 			}
-			buffer, err = lan.AvailableBuffers()
+			buffer, _, err = lan.AvailableBuffers()
 			bytesRead += len(buffer)
 			if err != nil {
 				return

--- a/lancero/cmd/oddashtx/oddashtx.go
+++ b/lancero/cmd/oddashtx/oddashtx.go
@@ -55,7 +55,7 @@ func main() {
 			if err != nil {
 				return
 			}
-			buffer, _, err = lan.AvailableBuffers()
+			buffer, _, err = lan.AvailableBuffer()
 			bytesRead += len(buffer)
 			if err != nil {
 				return

--- a/lancero/lancero.go
+++ b/lancero/lancero.go
@@ -25,7 +25,7 @@ type Lanceroer interface {
 	StartCollector(bool) error
 	StopCollector() error
 	Wait() (time.Time, time.Duration, error)
-	AvailableBuffers() ([]byte, error)
+	AvailableBuffers() ([]byte, time.Time, error)
 	ReleaseBytes(int) error
 	InspectAdapter() uint32
 }
@@ -124,7 +124,7 @@ func (lan *Lancero) Wait() (time.Time, time.Duration, error) {
 }
 
 // AvailableBuffers returns a COPY OF the ring buffer segment now ready for reading.
-func (lan *Lancero) AvailableBuffers() ([]byte, error) {
+func (lan *Lancero) AvailableBuffers() ([]byte, time.Time, error) {
 	return lan.adapter.availableBuffers()
 }
 

--- a/lancero/lancero.go
+++ b/lancero/lancero.go
@@ -25,7 +25,7 @@ type Lanceroer interface {
 	StartCollector(bool) error
 	StopCollector() error
 	Wait() (time.Time, time.Duration, error)
-	AvailableBuffers() ([]byte, time.Time, error)
+	AvailableBuffer() ([]byte, time.Time, error)
 	ReleaseBytes(int) error
 	InspectAdapter() uint32
 }
@@ -123,9 +123,14 @@ func (lan *Lancero) Wait() (time.Time, time.Duration, error) {
 	return lan.adapter.wait()
 }
 
-// AvailableBuffers returns a COPY OF the ring buffer segment now ready for reading.
-func (lan *Lancero) AvailableBuffers() ([]byte, time.Time, error) {
-	return lan.adapter.availableBuffers()
+// AvailableBuffer returns a COPY OF the ring buffer segment now ready for reading,
+// plus the best estimate of the time stamp taken immediately after the end of the
+// segment, and any error.
+// Because this returns a COPY, it is encouraged to call ReleaseBytes as soon as the
+// caller is sure how many bytes are to be released, even if the caller is not done
+// using the copy of the data.
+func (lan *Lancero) AvailableBuffer() ([]byte, time.Time, error) {
+	return lan.adapter.availableBuffer()
 }
 
 // ReleaseBytes instructed the ring buffer adapter to release nBytes bytes for over-writing.

--- a/lancero/lancero_adapter.go
+++ b/lancero/lancero_adapter.go
@@ -136,11 +136,15 @@ func (a *adapter) allocateRingBuffer(length, threshold int) error {
 }
 
 // Find total amount of available data and return a buffer (byte slice).
-// Returns the data buffer and any possible error.
-func (a *adapter) availableBuffers() (buffer []byte, err error) {
+// Returns the data buffer, the time fix of that buffer, and any possible error.
+func (a *adapter) availableBuffers() (buffer []byte, timefix time.Time, err error) {
 	// Ask the hardware for the current write pointer and the bytes available.
 	// Note that "write pointer" is where the DRIVER is about to write to.
+	// It's important to put the time fix as close as possible to the time that
+	// we read the write pointer, because we want a time stamp on the ever-changing
+	// write pointer value.
 	a.writeIndex, err = a.device.readRegister(adapterRBWI)
+	timefix = time.Now()
 	if err != nil {
 		return
 	}

--- a/lancero/lancero_adapter.go
+++ b/lancero/lancero_adapter.go
@@ -137,7 +137,7 @@ func (a *adapter) allocateRingBuffer(length, threshold int) error {
 
 // Find total amount of available data and return a buffer (byte slice).
 // Returns the data buffer, the time fix of that buffer, and any possible error.
-func (a *adapter) availableBuffers() (buffer []byte, timefix time.Time, err error) {
+func (a *adapter) availableBuffer() (buffer []byte, timefix time.Time, err error) {
 	// Ask the hardware for the current write pointer and the bytes available.
 	// Note that "write pointer" is where the DRIVER is about to write to.
 	// It's important to put the time fix as close as possible to the time that

--- a/lancero/lancero_test.go
+++ b/lancero/lancero_test.go
@@ -79,13 +79,12 @@ func testLanceroerSubroutine(lan Lanceroer, t *testing.T) (int, int, int, error)
 			if err != nil {
 				return 0, 0, 0, fmt.Errorf("lan.Wait: %v", err)
 			}
-			buffer, _, err := lan.AvailableBuffers()
+			buffer, _, err := lan.AvailableBuffer()
 			totalBytes := len(buffer)
 			// fmt.Printf("waittime: %v\n", waittime)
 			if err != nil {
 				return 0, 0, 0, fmt.Errorf("lan.AvailableBuffers: %v", err)
 			}
-			// fmt.Printf("Found buffers with %9d total bytes, bytes read previously=%10d\n", totalBytes, bytesRead)
 			if totalBytes > 0 {
 				q, p, n, err := FindFrameBits(buffer)
 				bytesPerFrame := 4 * (p - q)

--- a/lancero/lancero_test.go
+++ b/lancero/lancero_test.go
@@ -85,6 +85,7 @@ func testLanceroerSubroutine(lan Lanceroer, t *testing.T) (int, int, int, error)
 			if err != nil {
 				return 0, 0, 0, fmt.Errorf("lan.AvailableBuffers: %v", err)
 			}
+			// fmt.Printf("Found buffers with %9d total bytes, bytes read previously=%10d\n", totalBytes, bytesRead)
 			if totalBytes > 0 {
 				q, p, n, err := FindFrameBits(buffer)
 				bytesPerFrame := 4 * (p - q)

--- a/lancero/lancero_test.go
+++ b/lancero/lancero_test.go
@@ -79,7 +79,7 @@ func testLanceroerSubroutine(lan Lanceroer, t *testing.T) (int, int, int, error)
 			if err != nil {
 				return 0, 0, 0, fmt.Errorf("lan.Wait: %v", err)
 			}
-			buffer, err := lan.AvailableBuffers()
+			buffer, _, err := lan.AvailableBuffers()
 			totalBytes := len(buffer)
 			// fmt.Printf("waittime: %v\n", waittime)
 			if err != nil {

--- a/lancero/no_hardware.go
+++ b/lancero/no_hardware.go
@@ -112,25 +112,25 @@ func (lan *NoHardware) Wait() (time.Time, time.Duration, error) {
 // AvailableBuffers some simulated data
 // size matches what you should get in 1 millisecond
 // all entries other than frame bits are zeros
-func (lan *NoHardware) AvailableBuffers() ([]byte, error) {
+func (lan *NoHardware) AvailableBuffers() ([]byte, time.Time, error) {
 	var buf bytes.Buffer
+	now := time.Now()
 	if !lan.isStarted {
-		return buf.Bytes(), fmt.Errorf("err in NoHardware.AvailableBuffers: not started: id %v", lan.idNum)
+		return buf.Bytes(), now, fmt.Errorf("err in NoHardware.AvailableBuffers: not started: id %v", lan.idNum)
 	}
 	if !lan.collectorStarted {
-		return buf.Bytes(), fmt.Errorf("err in NoHardware.AvailableBuffers: collector not started: id %v", lan.idNum)
+		return buf.Bytes(), now, fmt.Errorf("err in NoHardware.AvailableBuffers: collector not started: id %v", lan.idNum)
 	}
 	if !lan.isOpen {
-		return buf.Bytes(), fmt.Errorf("err in NoHardware.AvailableBuffers: not open: id %v", lan.idNum)
+		return buf.Bytes(), now, fmt.Errorf("err in NoHardware.AvailableBuffers: not open: id %v", lan.idNum)
 	}
-	now := time.Now()
 	sinceLastRead := now.Sub(lan.lastReadTime)
 	lan.lastReadTime = now
 	frameDurationNanoseconds := lan.linePeriod * lan.nanoSecondsPerLinePeriod * lan.nrows
 	frames := int(sinceLastRead.Nanoseconds()) / frameDurationNanoseconds
 	// fmt.Printf("id %v read at %v\n", lan.idNum, time.Now())
 	if sinceLastRead > 50*lan.minTimeBetweenReads {
-		return buf.Bytes(), fmt.Errorf("reads were %v apart, want < %v", sinceLastRead, 50*lan.minTimeBetweenReads)
+		return buf.Bytes(), now, fmt.Errorf("reads were %v apart, want < %v", sinceLastRead, 50*lan.minTimeBetweenReads)
 	}
 
 	for i := 0; i < frames; i++ { // i counts frames
@@ -149,7 +149,7 @@ func (lan *NoHardware) AvailableBuffers() ([]byte, error) {
 		}
 
 	}
-	return buf.Bytes(), nil
+	return buf.Bytes(), now, nil
 }
 
 // ReleaseBytes increments bytesReleased

--- a/lancero/no_hardware.go
+++ b/lancero/no_hardware.go
@@ -109,10 +109,10 @@ func (lan *NoHardware) Wait() (time.Time, time.Duration, error) {
 	return now, now.Sub(lan.lastReadTime), nil
 }
 
-// AvailableBuffers some simulated data
+// AvailableBuffer returns some simulated data
 // size matches what you should get in 1 millisecond
 // all entries other than frame bits are zeros
-func (lan *NoHardware) AvailableBuffers() ([]byte, time.Time, error) {
+func (lan *NoHardware) AvailableBuffer() ([]byte, time.Time, error) {
 	var buf bytes.Buffer
 	now := time.Now()
 	if !lan.isStarted {

--- a/lancero_source.go
+++ b/lancero_source.go
@@ -285,7 +285,7 @@ func (device *LanceroDevice) sampleCard() error {
 			if err != nil {
 				return err
 			}
-			buffer, _, err = lan.AvailableBuffers()
+			buffer, _, err = lan.AvailableBuffer()
 
 			if err != nil {
 				return err
@@ -389,10 +389,10 @@ func (ls *LanceroSource) StartRun() error {
 			if _, _, err := lan.Wait(); err != nil {
 				return fmt.Errorf("error in Wait: %v", err)
 			}
-			bytes, _, err := lan.AvailableBuffers()
+			bytes, _, err := lan.AvailableBuffer()
 			bytesRead += len(bytes)
 			if err != nil {
-				return fmt.Errorf("error in AvailableBuffers: %v", err)
+				return fmt.Errorf("error in AvailableBuffer: %v", err)
 			}
 			if len(bytes) <= 0 {
 				continue
@@ -457,9 +457,9 @@ func (ls *LanceroSource) distributeData() {
 	var buffers [][]RawType
 	var lastSampleTime time.Time
 	for _, dev := range ls.active {
-		b, timeFix, err := dev.card.AvailableBuffers()
+		b, timeFix, err := dev.card.AvailableBuffer()
 		if err != nil {
-			log.Printf("Warning: AvailableBuffers failed")
+			log.Printf("Warning: AvailableBuffer failed")
 			return
 		}
 		buffers = append(buffers, bytesToRawType(b))

--- a/lancero_source.go
+++ b/lancero_source.go
@@ -195,6 +195,7 @@ func (ls *LanceroSource) Sample() error {
 		ls.nchan += device.ncols * device.nrows * 2
 		ls.sampleRate = float64(device.clockMhz) * 1e6 / float64(device.lsync*device.nrows)
 	}
+	ls.samplePeriod = time.Duration(roundint(1e9 / ls.sampleRate))
 	ls.updateChanOrderMap()
 
 	ls.signed = make([]bool, ls.nchan)
@@ -529,6 +530,7 @@ func (ls *LanceroSource) distributeData() {
 		seg := DataSegment{
 			rawData:         data,
 			framesPerSample: 1, // This will be changed later if decimating
+			framePeriod:     ls.samplePeriod,
 			firstFramenum:   ls.nextFrameNum,
 			firstTime:       firstTime,
 		}

--- a/lancero_test.go
+++ b/lancero_test.go
@@ -79,6 +79,7 @@ func TestNoHardwareSource(t *testing.T) {
 	nrowsSet = 4
 	linePeriodSet = 400 // don't make this too low, or test -race will fail
 	nLancero = 3
+	ntes := ncolsSet * nrowsSet * nLancero
 	source := new(LanceroSource)
 	source.devices = make(map[int]*LanceroDevice, nLancero)
 	cardDelay := []int{0} // a single card delay value works for multiple cards
@@ -127,13 +128,13 @@ func TestNoHardwareSource(t *testing.T) {
 	defer source.Stop()
 
 	if source.chanNumbers[3] != 2 {
-		t.Errorf("have %v, want 2", source.chanNumbers[3])
+		t.Errorf("LanceroSource.chanNumbers[3] has %v, want 2", source.chanNumbers[3])
 	}
 	if strings.Compare(source.chanNames[3], "chan2") != 0 {
-		t.Errorf("have %v, want chan2", source.chanNames[3])
+		t.Errorf("LanceroSource.chanNames[3] has %v, want chan2", source.chanNames[3])
 	}
 	if strings.Compare(source.chanNames[2], "err2") != 0 {
-		t.Errorf("have %v, want chan2", source.chanNames[3])
+		t.Errorf("LanceroSource.chanNames[2] %v, want err2", source.chanNames[3])
 	}
 	if err := source.ConfigureMixFraction(0, 1.0); err == nil {
 		t.Error("expected error for mixing on even channel")
@@ -142,7 +143,6 @@ func TestNoHardwareSource(t *testing.T) {
 		t.Error(err)
 	}
 	time.Sleep(20 * time.Millisecond) // wait long enough for some data to be processed
-
 }
 
 func TestMix(t *testing.T) {

--- a/lancero_test.go
+++ b/lancero_test.go
@@ -79,7 +79,6 @@ func TestNoHardwareSource(t *testing.T) {
 	nrowsSet = 4
 	linePeriodSet = 400 // don't make this too low, or test -race will fail
 	nLancero = 3
-	ntes := ncolsSet * nrowsSet * nLancero
 	source := new(LanceroSource)
 	source.devices = make(map[int]*LanceroDevice, nLancero)
 	cardDelay := []int{0} // a single card delay value works for multiple cards

--- a/process_data.go
+++ b/process_data.go
@@ -125,7 +125,6 @@ func (dsp *DataStreamProcessor) processSegment(segment *DataSegment) {
 
 	dsp.DecimateData(segment)
 	dsp.stream.AppendSegment(segment)
-	// records, secondaries := dsp.TriggerData()
 	records, _ := dsp.TriggerData()
 	dsp.AnalyzeData(records)               // add analysis results to records in-place
 	dsp.DataPublisher.PublishData(records) // publish and save data, when enabled

--- a/simulated_data_sources.go
+++ b/simulated_data_sources.go
@@ -59,6 +59,8 @@ func (ts *TriangleSource) Configure(config *TriangleSourceConfig) error {
 	}
 	ts.nchan = config.Nchan
 	ts.sampleRate = config.SampleRate
+	ts.samplePeriod = time.Duration(roundint(1e9 / ts.sampleRate))
+
 	ts.minval = config.Min
 	ts.maxval = config.Max
 	cycleTime := float64(ts.cycleLen) / ts.sampleRate
@@ -108,6 +110,7 @@ func (ts *TriangleSource) blockingRead() error {
 		seg := DataSegment{
 			rawData:         datacopy,
 			framesPerSample: 1,
+			framePeriod:     ts.samplePeriod,
 			firstFramenum:   ts.nextFrameNum,
 			firstTime:       firstTime,
 		}
@@ -151,6 +154,7 @@ func (sps *SimPulseSource) Configure(config *SimPulseSourceConfig) error {
 	}
 	sps.nchan = config.Nchan
 	sps.sampleRate = config.SampleRate
+	sps.samplePeriod = time.Duration(roundint(1e9 / sps.sampleRate))
 
 	sps.cycleLen = config.Nsamp
 	firstIdx := 5
@@ -220,6 +224,7 @@ func (sps *SimPulseSource) blockingRead() error {
 		seg := DataSegment{
 			rawData:         datacopy,
 			framesPerSample: 1,
+			framePeriod:     sps.samplePeriod,
 			firstFramenum:   sps.nextFrameNum,
 			firstTime:       firstTime,
 		}


### PR DESCRIPTION
Commit e02358f fixes #39 this in grand fashion for the Lancero source. In my test case, there are 1375 records taken with 250 ms pulse auto-triggers, so over 5 minutes of data.  Every record is 34722 frames apart, as expected (7.2 µs timebase, so 34722 frames = 249.9984 ms).

But the cool part is that the mean time between records' timestamps is 250.003 ms with a standard deviation of 3.77 µs. Hooray!

While the standard deviation for simulated pulse sources is more like 50 µs, we also don't really care.

One problem with this PR is that it doesn't have a test to exercise the bug. Unfortunately, the bug lived in `func (ls *LanceroSource) distributeData()`, and I don't know how to test that without actual hardware. Could something go in `TestNoHardwareSource` ?