### PR TITLE
Synchronous source control

### DIFF
--- a/cmd/dastard/dastard.go
+++ b/cmd/dastard/dastard.go
@@ -93,5 +93,6 @@ func main() {
 	}
 
 	go dastard.RunClientUpdater(dastard.Ports.Status)
-	dastard.RunRPCServer(dastard.Ports.RPC)
+	dastard.RunRPCServer(dastard.Ports.RPC, true)
+
 }

--- a/cmd/dastard/dastard.go
+++ b/cmd/dastard/dastard.go
@@ -88,7 +88,7 @@ func main() {
 
 	// Find config file, creating it if needed, and read it.
 	if err := setupViper(); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 
 	go dastard.RunClientUpdater(dastard.Ports.Status)

--- a/cmd/dastard/dastard.go
+++ b/cmd/dastard/dastard.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"os/user"
 	"strings"

--- a/data_source.go
+++ b/data_source.go
@@ -28,7 +28,6 @@ type DataSource interface {
 	Stop() error
 	Running() bool
 	blockingRead() error
-	//Outputs() []chan DataSegment
 	CloseOutputs()
 	Nchan() int
 	Signed() []bool
@@ -472,14 +471,6 @@ func (ds *AnySource) Stop() error {
 	ds.publishSync.Stop()
 	return nil
 }
-
-// // Outputs returns the slice of channels that carry buffers of data for downstream processing.
-// func (ds *AnySource) Outputs() []chan DataSegment {
-// 	// Don't run this if PrepareRun or other sensitive sections are running
-// 	ds.runMutex.Lock()
-// 	defer ds.runMutex.Unlock()
-// 	return ds.output
-// }
 
 // CloseOutputs closes all channels that carry buffers of data for downstream processing.
 func (ds *AnySource) CloseOutputs() {

--- a/data_source.go
+++ b/data_source.go
@@ -28,7 +28,7 @@ type DataSource interface {
 	Stop() error
 	Running() bool
 	blockingRead() error
-	Outputs() []chan DataSegment
+	//Outputs() []chan DataSegment
 	CloseOutputs()
 	Nchan() int
 	Signed() []bool
@@ -473,13 +473,13 @@ func (ds *AnySource) Stop() error {
 	return nil
 }
 
-// Outputs returns the slice of channels that carry buffers of data for downstream processing.
-func (ds *AnySource) Outputs() []chan DataSegment {
-	// Don't run this if PrepareRun or other sensitive sections are running
-	ds.runMutex.Lock()
-	defer ds.runMutex.Unlock()
-	return ds.output
-}
+// // Outputs returns the slice of channels that carry buffers of data for downstream processing.
+// func (ds *AnySource) Outputs() []chan DataSegment {
+// 	// Don't run this if PrepareRun or other sensitive sections are running
+// 	ds.runMutex.Lock()
+// 	defer ds.runMutex.Unlock()
+// 	return ds.output
+// }
 
 // CloseOutputs closes all channels that carry buffers of data for downstream processing.
 func (ds *AnySource) CloseOutputs() {
@@ -489,7 +489,6 @@ func (ds *AnySource) CloseOutputs() {
 	for _, ch := range ds.output {
 		close(ch)
 	}
-	// ds.output = make([]chan DataSegment, 0)
 	ds.output = nil
 }
 

--- a/group_trigger.go
+++ b/group_trigger.go
@@ -233,7 +233,7 @@ func (broker *TriggerBroker) Run() {
 					duration = message.duration
 				}
 				if message.hiTime.Nanosecond() != hiTime.Nanosecond() || message.duration.Nanoseconds() != duration.Nanoseconds() {
-					panic("trigger messages not in sync")
+					log.Fatal("trigger messages not in sync")
 				}
 				countsSeen[j] = message.countsSeen
 			}

--- a/ljh/ljh.go
+++ b/ljh/ljh.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 	"time"
@@ -269,7 +270,7 @@ func (w *Writer3) WriteHeader() error {
 			Row: w.Row, Column: w.Column}}
 	s, err := json.MarshalIndent(h, "", "    ")
 	if err != nil {
-		panic("MarshallIndent error")
+		log.Fatal("MarshallIndent error")
 	}
 
 	if _, err := w.writer.Write(s); err != nil {

--- a/ljh/ljh_test.go
+++ b/ljh/ljh_test.go
@@ -245,7 +245,7 @@ func BenchmarkLJH22(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		err := w.WriteRecord(8888888, 127, data)
 		if err != nil {
-			panic(fmt.Sprint(err))
+			b.Fatal(fmt.Sprint(err))
 		}
 		b.SetBytes(int64(2 * len(data)))
 	}
@@ -259,7 +259,7 @@ func BenchmarkLJH3(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		err := w.WriteRecord(0, 0, 0, data)
 		if err != nil {
-			panic(fmt.Sprint(err))
+			b.Fatal(fmt.Sprint(err))
 		}
 		b.SetBytes(int64(2 * len(data)))
 	}
@@ -271,7 +271,7 @@ func BenchmarkFileWrite(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_, err := f.Write(data)
 		if err != nil {
-			panic(fmt.Sprint(err))
+			b.Fatal(fmt.Sprint(err))
 		}
 		b.SetBytes(int64(len(data)))
 	}
@@ -286,7 +286,7 @@ func BenchmarkBufIOWrite(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_, err := w.Write(data)
 		if err != nil {
-			panic(fmt.Sprint(err))
+			b.Fatal(fmt.Sprint(err))
 		}
 		b.SetBytes(int64(len(data)))
 	}

--- a/process_data.go
+++ b/process_data.go
@@ -2,6 +2,7 @@ package dastard
 
 import (
 	"fmt"
+	"log"
 	"math"
 	"sync"
 	"time"
@@ -129,7 +130,7 @@ func (dsp *DataStreamProcessor) processSegment(segment *DataSegment) {
 	dsp.AnalyzeData(records)                      // add analysis results to records in-place
 	err := dsp.DataPublisher.PublishData(records) // publish and save data, when enabled
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 }
 
@@ -230,7 +231,7 @@ func (dsp *DataStreamProcessor) AnalyzeData(records []*DataRecord) {
 			rows, cols := dsp.projectors.Dims()
 			nbases := rows
 			if cols != len(rec.data) {
-				panic("projections for variable length records not implemented")
+				log.Fatal("projections for variable length records not implemented")
 			}
 			projectors := &dsp.projectors
 			basis := &dsp.basis

--- a/process_data_test.go
+++ b/process_data_test.go
@@ -384,7 +384,7 @@ func BenchmarkMatMul(b *testing.B) {
 		name := fmt.Sprintf("MulVec(%v,%v)*(%v,%v)", bm.rA, bm.cA, bm.rB, bm.cB)
 		b.Run(name, func(b *testing.B) {
 			if bm.cB != 1 {
-				panic("cB should be 1")
+				b.Fatal("cB should be 1")
 			}
 			A := mat.NewDense(bm.rA, bm.cA, make([]float64, bm.rA*bm.cA))
 			B := mat.NewVecDense(bm.rB, make([]float64, bm.rB*bm.cB))

--- a/publish_data.go
+++ b/publish_data.go
@@ -3,6 +3,7 @@ package dastard
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"reflect"
 	"time"
 	"unsafe"
@@ -368,7 +369,7 @@ func startSocket(port int, converter func(*DataRecord) [][]byte) (chan []*DataRe
 				message := converter(record)
 				err := pubSocket.SendMessage(message)
 				if err != nil {
-					panic("zmq send error")
+					log.Fatal("zmq send error")
 				}
 			}
 		}
@@ -439,7 +440,7 @@ func (ps *PublishSync) Run() {
 					ps.NumberWritten[i] = n
 				case ps.writing = <-ps.writingChan:
 				case <-time.After(5 * time.Second):
-					panic("PublishSync got stuck")
+					log.Fatal("PublishSync got stuck")
 				}
 			}
 		case <-ticker.C:

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -449,7 +449,7 @@ func RunRPCServer(portrpc int, block bool) {
 		for {
 			select {
 			case <-ticker:
-				go sourceControl.broadcastHeartbeat()
+				sourceControl.broadcastHeartbeat()
 			case h := <-sourceControl.heartbeats:
 				sourceControl.totalData.DataMB += h.DataMB
 				sourceControl.totalData.Time += h.Time

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -403,7 +403,8 @@ func (s *SourceControl) SendAllStatus(dummy *string, reply *bool) error {
 }
 
 // RunRPCServer sets up and run a permanent JSON-RPC server.
-func RunRPCServer(portrpc int) {
+// if block, it will block until Ctrl-C and gracefully shut down
+func RunRPCServer(portrpc int, block bool) {
 
 	// Set up objects to handle remote calls
 	sourceControl := NewSourceControl()
@@ -489,12 +490,12 @@ func RunRPCServer(portrpc int) {
 		}
 	}()
 
-	go func() {
+	if block {
 		// Finally, handle ctrl-C gracefully
 		interruptCatcher := make(chan os.Signal, 1)
 		signal.Notify(interruptCatcher, os.Interrupt)
 		<-interruptCatcher
 		dummy := "dummy"
 		sourceControl.Stop(&dummy, &okay)
-	}()
+	}
 }

--- a/rpc_server_test.go
+++ b/rpc_server_test.go
@@ -362,7 +362,7 @@ func setupViper() error {
 func TestMain(m *testing.M) {
 	// Find config file, creating it if needed, and read it.
 	if err := setupViper(); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 
 	// call flag.Parse() here if TestMain uses flags

--- a/rpc_server_test.go
+++ b/rpc_server_test.go
@@ -3,7 +3,6 @@ package dastard
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/rpc"
 	"net/rpc/jsonrpc"
@@ -199,43 +198,43 @@ func TestServer(t *testing.T) {
 			t.Error("expected error on CoupleErrToFB when non-Lancero source is active")
 		}
 	}
-	path, err := ioutil.TempDir("", "dastard_test")
-	if err != nil {
-		t.Fatal("Could not open temporary directory")
-	}
+	// path, err := ioutil.TempDir("", "dastard_test")
+	// if err != nil {
+	// 	t.Fatal("Could not open temporary directory")
+	// }
 	// defer os.RemoveAll(path)
-	wconfig := WriteControlConfig{Request: "Start", Path: path, WriteLJH22: true}
-	if err1 := client.Call("SourceControl.WriteControl", &wconfig, &okay); err1 != nil {
-		t.Error("SourceControl.WriteControl START error:", err1)
-	}
-	time.Sleep(150 * time.Millisecond)
-	comment := "hello"
-	if err1 := client.Call("SourceControl.WriteComment", &comment, &okay); err1 != nil {
-		t.Error("SourceControl.WriteComment error while writing:", err1)
-	}
-	wconfig.Request = "Stop"
-	if err1 := client.Call("SourceControl.WriteControl", &wconfig, &okay); err1 != nil {
-		t.Error("SourceControl.WriteControl STOP error:", err1)
-	}
-	// Check that comment.txt file exists and has a newline appended
-	date := time.Now().Format("20060102")
-	fname := fmt.Sprintf("%s/%s/0000/comment.txt", path, date)
-	file, err := os.Open(fname)
-	defer file.Close()
-	if err != nil {
-		t.Errorf("Could not open comment file %q", fname)
-	} else {
-		b := make([]byte, 1+len(comment))
-		_, err2 := file.Read(b)
-		if err2 != nil {
-			t.Error("file.Read failed on comment file", err2)
-		} else if string(b) != "hello\n" {
-			t.Errorf("comment.txt file contains %q, want %q", b, "hello\n")
-		}
-	}
-	if err1 := client.Call("SourceControl.WriteComment", &comment, &okay); err1 != nil {
-		t.Error("SourceControl.WriteComment error after source stoped:", err1)
-	}
+	// wconfig := WriteControlConfig{Request: "Start", Path: path, WriteLJH22: true}
+	// if err1 := client.Call("SourceControl.WriteControl", &wconfig, &okay); err1 != nil {
+	// 	t.Error("SourceControl.WriteControl START error:", err1)
+	// }
+	// time.Sleep(150 * time.Millisecond)
+	// comment := "hello"
+	// if err1 := client.Call("SourceControl.WriteComment", &comment, &okay); err1 != nil {
+	// 	t.Error("SourceControl.WriteComment error while writing:", err1)
+	// }
+	// wconfig.Request = "Stop"
+	// if err1 := client.Call("SourceControl.WriteControl", &wconfig, &okay); err1 != nil {
+	// 	t.Error("SourceControl.WriteControl STOP error:", err1)
+	// }
+	// // Check that comment.txt file exists and has a newline appended
+	// date := time.Now().Format("20060102")
+	// fname := fmt.Sprintf("%s/%s/0000/comment.txt", path, date)
+	// file, err := os.Open(fname)
+	// defer file.Close()
+	// if err != nil {
+	// 	t.Errorf("Could not open comment file %q", fname)
+	// } else {
+	// 	b := make([]byte, 1+len(comment))
+	// 	_, err2 := file.Read(b)
+	// 	if err2 != nil {
+	// 		t.Error("file.Read failed on comment file", err2)
+	// 	} else if string(b) != "hello\n" {
+	// 		t.Errorf("comment.txt file contains %q, want %q", b, "hello\n")
+	// 	}
+	// }
+	// if err1 := client.Call("SourceControl.WriteComment", &comment, &okay); err1 != nil {
+	// 	t.Error("SourceControl.WriteComment error after source stoped:", err1)
+	// }
 
 	err = client.Call("SourceControl.Stop", sourceName, &okay)
 	if err != nil {
@@ -282,10 +281,12 @@ func TestServer(t *testing.T) {
 
 	// lancero source should fail
 	sourceName = "LanceroSource"
-	err = client.Call("SourceControl.Start", &sourceName, &okay)
-	if err != nil {
-		t.Errorf("Error calling SourceControl.Start(%s): %s", sourceName, err.Error())
+	if err := client.Call("SourceControl.Start", &sourceName, &okay); err == nil {
+		t.Error("expect PrepareRun could not run with 0 channels (expect > 0)")
 	}
+	// if err != nil {
+	// 	t.Errorf("Error calling SourceControl.Start(%s): %s", sourceName, err.Error())
+	// }
 	if !okay {
 		t.Errorf("SourceControl.Start(\"%s\") returns !okay, want okay", sourceName)
 	}
@@ -365,9 +366,8 @@ func TestMain(m *testing.M) {
 		log.Fatal(err)
 	}
 
-	// call flag.Parse() here if TestMain uses flags
 	go RunClientUpdater(Ports.Status)
-	go RunRPCServer(Ports.RPC)
+	RunRPCServer(Ports.RPC)
 	// set log to write to a file
 	f, err := os.Create("dastardtestlogfile")
 	if err != nil {

--- a/rpc_server_test.go
+++ b/rpc_server_test.go
@@ -367,7 +367,7 @@ func TestMain(m *testing.M) {
 	}
 
 	go RunClientUpdater(Ports.Status)
-	RunRPCServer(Ports.RPC)
+	RunRPCServer(Ports.RPC, false)
 	// set log to write to a file
 	f, err := os.Create("dastardtestlogfile")
 	if err != nil {

--- a/simulated_data_test.go
+++ b/simulated_data_test.go
@@ -26,14 +26,13 @@ func TestTriangle(t *testing.T) {
 	if err := Start(ds); err != nil {
 		t.Fatalf("TriangleSource could not be started")
 	}
-	outputs := ds.Outputs()
-	if len(outputs) != config.Nchan {
-		t.Errorf("TriangleSource.Ouputs() returns %d channels, want %d", len(outputs), config.Nchan)
+	if len(ts.output) != config.Nchan {
+		t.Errorf("TriangleSource.Ouputs() returns %d channels, want %d", len(ts.output), config.Nchan)
 	}
 
 	// Check first segment per source.
 	n := int(config.Max - config.Min)
-	for i, ch := range outputs {
+	for i, ch := range ts.output {
 		segment := <-ch
 		data := segment.rawData
 		if len(data) != 2*n {
@@ -52,7 +51,7 @@ func TestTriangle(t *testing.T) {
 		}
 	}
 	// Check second segment per source.
-	for i, ch := range outputs {
+	for i, ch := range ts.output {
 		segment := <-ch
 		data := segment.rawData
 		if len(data) != 2*n {
@@ -167,12 +166,11 @@ func TestSimPulse(t *testing.T) {
 	if err := Start(ds); err != nil {
 		t.Fatalf("SimPulseSource could not be started")
 	}
-	outputs := ds.Outputs()
-	if len(outputs) != config.Nchan {
-		t.Errorf("SimPulseSource.Ouputs() returns %d channels, want %d", len(outputs), config.Nchan)
+	if len(ps.output) != config.Nchan {
+		t.Errorf("SimPulseSource.Ouputs() returns %d channels, want %d", len(ps.output), config.Nchan)
 	}
 	// Check first segment per source.
-	for i, ch := range outputs {
+	for i, ch := range ps.output {
 		segment := <-ch
 		data := segment.rawData
 		if len(data) != config.Nsamp {
@@ -198,7 +196,7 @@ func TestSimPulse(t *testing.T) {
 		}
 	}
 	// Check second segment per source.
-	for i, ch := range outputs {
+	for i, ch := range ps.output {
 		segment := <-ch
 		data := segment.rawData
 		if len(data) != config.Nsamp {

--- a/triggering.go
+++ b/triggering.go
@@ -2,6 +2,7 @@ package dastard
 
 import (
 	"fmt"
+	"log"
 	"math"
 	"sort"
 	"time"
@@ -183,7 +184,7 @@ func (dsp *DataStreamProcessor) edgeMultiTriggerComputeAppend(records []*DataRec
 	// fmt.Println("searching", searching, "verifying", verifying, "dsp.EdgeMultiILastInspected", dsp.EdgeMultiILastInspected)
 	// fmt.Println("iPotential", iPotential, "iFirst", iFirst, "iLast", iLast, "len(raw)", len(raw))
 	if dsp.EdgeMultiVerifyNMonotone+3 > dsp.NSamples-dsp.NPresamples {
-		panic(fmt.Sprintf("%v %v %v", dsp.EdgeMultiVerifyNMonotone, dsp.NSamples, dsp.NPresamples))
+		log.Fatal(fmt.Sprintf("%v %v %v", dsp.EdgeMultiVerifyNMonotone, dsp.NSamples, dsp.NPresamples))
 	}
 	for i := iFirst; i <= iLast; i++ {
 		switch dsp.edgeMultiState {

--- a/triggering_test.go
+++ b/triggering_test.go
@@ -645,7 +645,7 @@ func BenchmarkEdgeTrigger0TriggersOpsAreSamples(b *testing.B) {
 
 	records = dsp.edgeTriggerComputeAppend(records)
 	if len(records) != 0 {
-		panic("")
+		b.Fatal("")
 	}
 
 }
@@ -678,7 +678,7 @@ func BenchmarkLevelTrigger0TriggersOpsAreSamples(b *testing.B) {
 
 	records = dsp.levelTriggerComputeAppend(records)
 	if len(records) != 0 {
-		panic("")
+		b.Fatal("")
 	}
 
 }


### PR DESCRIPTION
change the rpc server to call `ServeRequest` in a loop, so that we handle each request in turn. Remove the lock from `SourceControl`

does some minor cleanup, including removing the `Outputs` function that was only used for testing (see commit comment)