### PR TITLE
Send a NEWDASTARD message when server starts

### DIFF
--- a/client_updater.go
+++ b/client_updater.go
@@ -34,18 +34,25 @@ func publish(pubSocket *czmq.Sock, update ClientUpdate, message []byte) {
 var clientMessageChan chan ClientUpdate
 
 func init() {
-	clientMessageChan = make(chan ClientUpdate)
+	clientMessageChan = make(chan ClientUpdate, 10)
 }
 
 // RunClientUpdater forwards any message from its input channel to the ZMQ publisher socket
 // to publish any information that clients need to know.
-func RunClientUpdater(portstatus int) {
-	hostname := fmt.Sprintf("tcp://*:%d", portstatus)
+func RunClientUpdater(statusport int) {
+	hostname := fmt.Sprintf("tcp://*:%d", statusport)
 	pubSocket, err := czmq.NewPub(hostname)
 	if err != nil {
 		return
 	}
 	defer pubSocket.Destroy()
+
+	// The ZMQ middleware will need some time for existing SUBscribers (and their
+	// subscription topics) to be hooked up to this new PUBlisher.
+	// The result is that the first few messages will be dropped, including the
+	// NEWDASTARD one. By sleeping a fraction of a second, we can avoid this
+	// dropped-message problem most of the time (though there's no guarantee).
+	time.Sleep(250 * time.Millisecond)
 
 	// Save the state to the standard saved-state file this often.
 	savePeriod := time.Minute
@@ -73,7 +80,13 @@ func RunClientUpdater(portstatus int) {
 			// Send state to clients now.
 			message, err := json.Marshal(update.state)
 			if err == nil {
+				fmt.Printf("Publishing %s message\n", update.tag)
 				publish(pubSocket, update, message)
+			}
+
+			// Don't save NEWDASTARD messages--they don't contain state
+			if update.tag == "NEWDASTARD" {
+				continue
 			}
 
 			// Check if the state has changed; if so, remember the message for later
@@ -108,6 +121,7 @@ var nosaveMessages = map[string]struct{}{
 	"alive":         {},
 	"triggerrate":   {},
 	"numberwritten": {},
+	"newdastard":    {},
 }
 
 // saveState stores server configuration to the standard config file.

--- a/cmd/dastard/dastard.go
+++ b/cmd/dastard/dastard.go
@@ -94,5 +94,4 @@ func main() {
 
 	go dastard.RunClientUpdater(dastard.Ports.Status)
 	dastard.RunRPCServer(dastard.Ports.RPC, true)
-
 }

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -413,6 +413,9 @@ func RunRPCServer(portrpc int, block bool) {
 	defer sourceControl.lancero.Delete()
 	sourceControl.clientUpdates = clientMessageChan
 
+	// Signal clients that there's a new Dastard running
+	sourceControl.clientUpdates <- ClientUpdate{"NEWDASTARD", "new Dastard is running"}
+
 	// Load stored settings, and transfer saved configuration
 	// from Viper to relevant objects.
 	var okay bool


### PR DESCRIPTION
Also, delay in sending ZMQ messages by 0.25 sec upon startup, so that ZMQ can get everything set up and avoid (or reduce probability of) dropping messages.

Fixes #79 and helps with dastard-commander issue 35.