### PR TITLE
Notice lancero problem

### DIFF
--- a/cmd/dastard/dastard.go
+++ b/cmd/dastard/dastard.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"os/user"
 	"strings"

--- a/cmd/dastard/dastard.go
+++ b/cmd/dastard/dastard.go
@@ -89,7 +89,7 @@ func main() {
 
 	// Find config file, creating it if needed, and read it.
 	if err := setupViper(); err != nil {
-		log.Fatal(err)
+		panic(err)
 	}
 
 	go dastard.RunClientUpdater(dastard.Ports.Status)

--- a/data_source.go
+++ b/data_source.go
@@ -468,13 +468,10 @@ func (ds *AnySource) PrepareRun() error {
 
 // Stop ends the data supply.
 func (ds *AnySource) Stop() error {
-	if ds.abortSelf != nil {
-		select {
-		case <-ds.abortSelf:
-		default:
-			close(ds.abortSelf)
-		}
+	if !ds.Running() {
+		return fmt.Errorf("Anysource not running, cannot stop")
 	}
+	close(ds.abortSelf)
 	ds.broker.Stop()
 	ds.publishSync.Stop()
 	ds.CloseOutputs()

--- a/data_source_test.go
+++ b/data_source_test.go
@@ -72,6 +72,7 @@ func TestWritingFiles(t *testing.T) {
 	ds := AnySource{nchan: 4}
 	ds.rowColCodes = make([]RowColCode, ds.nchan)
 	ds.PrepareRun()
+	defer ds.Stop()
 	config := &WriteControlConfig{Request: "Pause", Path: tmp, WriteLJH22: true}
 	var err error
 	for _, request := range []string{"Pause", "Unpause", "Stop"} {

--- a/group_trigger.go
+++ b/group_trigger.go
@@ -233,7 +233,7 @@ func (broker *TriggerBroker) Run() {
 					duration = message.duration
 				}
 				if message.hiTime.Nanosecond() != hiTime.Nanosecond() || message.duration.Nanoseconds() != duration.Nanoseconds() {
-					log.Fatal("trigger messages not in sync")
+					panic("trigger messages not in sync")
 				}
 				countsSeen[j] = message.countsSeen
 			}

--- a/lancero_test.go
+++ b/lancero_test.go
@@ -1,7 +1,6 @@
 package dastard
 
 import (
-	"strings"
 	"testing"
 	"time"
 
@@ -88,8 +87,7 @@ func TestNoHardwareSource(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		dev := LanceroDevice{card: lan}
-		dev.devnum = i
+		dev := LanceroDevice{card: lan, devnum: i}
 		source.devices[i] = &dev
 		activeCards[i] = i
 		source.ncards++
@@ -129,10 +127,10 @@ func TestNoHardwareSource(t *testing.T) {
 	if source.chanNumbers[3] != 2 {
 		t.Errorf("LanceroSource.chanNumbers[3] has %v, want 2", source.chanNumbers[3])
 	}
-	if strings.Compare(source.chanNames[3], "chan2") != 0 {
+	if source.chanNames[3] != "chan2" {
 		t.Errorf("LanceroSource.chanNames[3] has %v, want chan2", source.chanNames[3])
 	}
-	if strings.Compare(source.chanNames[2], "err2") != 0 {
+	if source.chanNames[2] != "err2" {
 		t.Errorf("LanceroSource.chanNames[2] %v, want err2", source.chanNames[3])
 	}
 	if err := source.ConfigureMixFraction(0, 1.0); err == nil {
@@ -142,6 +140,10 @@ func TestNoHardwareSource(t *testing.T) {
 		t.Error(err)
 	}
 	time.Sleep(20 * time.Millisecond) // wait long enough for some data to be processed
+	// these tests get lsync right at first, but while data is being processed
+	// the lsync is not right. about half the time I run the test there are 3 blocking reads
+	// at which point the lancero source shuts down due to it seeing lsync change
+	// then Stop() will error but the err value is not checked so it doesn't cause a test failure
 }
 
 func TestMix(t *testing.T) {

--- a/ljh/ljh.go
+++ b/ljh/ljh.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"time"
@@ -270,7 +269,7 @@ func (w *Writer3) WriteHeader() error {
 			Row: w.Row, Column: w.Column}}
 	s, err := json.MarshalIndent(h, "", "    ")
 	if err != nil {
-		log.Fatal("MarshallIndent error")
+		panic("MarshallIndent error")
 	}
 
 	if _, err := w.writer.Write(s); err != nil {

--- a/process_data.go
+++ b/process_data.go
@@ -2,7 +2,6 @@ package dastard
 
 import (
 	"fmt"
-	"log"
 	"math"
 	"sync"
 	"time"
@@ -125,7 +124,7 @@ func (dsp *DataStreamProcessor) processSegment(segment *DataSegment) {
 	dsp.AnalyzeData(records)                      // add analysis results to records in-place
 	err := dsp.DataPublisher.PublishData(records) // publish and save data, when enabled
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
 	}
 }
 
@@ -226,7 +225,7 @@ func (dsp *DataStreamProcessor) AnalyzeData(records []*DataRecord) {
 			rows, cols := dsp.projectors.Dims()
 			nbases := rows
 			if cols != len(rec.data) {
-				log.Fatal("projections for variable length records not implemented")
+				panic("projections for variable length records not implemented")
 			}
 			projectors := &dsp.projectors
 			basis := &dsp.basis

--- a/process_data_test.go
+++ b/process_data_test.go
@@ -177,6 +177,7 @@ func TestDataSignedness(t *testing.T) {
 	var ts TriangleSource
 	ts.nchan = 4
 	ts.PrepareRun()
+	defer ts.Stop()
 	for i, dsp := range ts.processors {
 		expect := false
 		if dsp.stream.signed != expect {
@@ -192,6 +193,7 @@ func TestDataSignedness(t *testing.T) {
 		ls.signed[i] = true
 	}
 	ls.PrepareRun()
+	defer ls.Stop()
 	for i, dsp := range ls.processors {
 		expect := (i % 2) == 0
 		if dsp.stream.signed != expect {

--- a/publish_data.go
+++ b/publish_data.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"math/rand"
 	"reflect"
 	"time"
 	"unsafe"
@@ -373,7 +374,7 @@ func startSocket(port int, converter func(*DataRecord) [][]byte) (chan []*DataRe
 				message := converter(record)
 				err := pubSocket.SendMessage(message)
 				if err != nil {
-					log.Fatal("zmq send error")
+					panic("zmq send error")
 				}
 			}
 		}
@@ -415,6 +416,7 @@ type PublishSync struct {
 	numberWrittenChans []chan int
 	NumberWritten      []int
 	abort              chan struct{} // This can signal the Run() goroutine to stop
+	id                 int
 }
 
 // NewPublishSync returns a *PublishSync for nchan channels
@@ -423,13 +425,15 @@ func NewPublishSync(nchan int) *PublishSync {
 	for i := 0; i < nchan; i++ {
 		numberWrittenChans[i] = make(chan int)
 	}
+	id := rand.Int() % 1000
 	return &PublishSync{numberWrittenChans: numberWrittenChans, abort: make(chan struct{}),
-		NumberWritten: make([]int, nchan), writingChan: make(chan bool)}
+		NumberWritten: make([]int, nchan), writingChan: make(chan bool), id: id}
 }
 
 // Run runs, collects number of records published, publishes summaries
 // should be called as a goroutine
 func (ps *PublishSync) Run() {
+	log.Println("PublishSync Run() id", ps.id)
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 	for {
@@ -444,7 +448,7 @@ func (ps *PublishSync) Run() {
 					ps.NumberWritten[i] = n
 				case ps.writing = <-ps.writingChan:
 				case <-time.After(5 * time.Second):
-					log.Fatal("PublishSync got stuck")
+					panic(fmt.Sprintf("PublishSync got stuck id %v", ps.id))
 				}
 			}
 		case <-ticker.C:
@@ -459,4 +463,5 @@ func (ps *PublishSync) Run() {
 // Stop causes the Run() goroutine to end at the next appropriate moment.
 func (ps *PublishSync) Stop() {
 	close(ps.abort)
+	log.Println("PublishSync.Stop() id", ps.id)
 }

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -274,7 +274,8 @@ func (s *SourceControl) Stop(dummy *string, reply *bool) error {
 	return nil
 }
 
-// observeSourceStop modifies s to make future messag
+// observeSourceStop modifies s to be correct after a source has stopped
+// it is either called in Stop() or in another routine which notices activeSource.Running() is false
 func (s *SourceControl) observeSourceStop() {
 	s.status.Running = false
 	s.activeSource = nil

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -261,8 +261,6 @@ func (s *SourceControl) Stop(dummy *string, reply *bool) error {
 	s.status.Running = false
 	s.activeSource = nil
 	*reply = true
-	// The following can't run without holding the s.mu lock, so it needs
-	// to be launched in a separate goroutine.
 	s.broadcastStatus()
 	*reply = true
 	return nil
@@ -319,10 +317,9 @@ type CouplingStatus int
 
 // Specific allowed values for status of FB / error coupling
 const (
-	// FB and error aren't coupled
-	NoCoupling CouplingStatus = iota + 1
-	FBToErr                   // FB triggers cause secondary triggers in error channels
-	ErrToFB                   // Error triggers cause secondary triggers in FB channels
+	NoCoupling CouplingStatus = iota + 1 // NoCoupling turns off FB + error coupling
+	FBToErr                              // FB triggers cause secondary triggers in error channels
+	ErrToFB                              // Error triggers cause secondary triggers in FB channels
 )
 
 // CoupleErrToFB turns on or off coupling of Error -> FB

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -361,6 +361,9 @@ func (s *SourceControl) CoupleFBToErr(couple *bool, reply *bool) error {
 }
 
 func (s *SourceControl) broadcastHeartbeat() {
+	if s.activeSource != nil {
+		s.status.Running = s.activeSource.Running() // check for source stopping on its own, eg lancero source stops for server state change
+	}
 	s.totalData.Running = s.status.Running
 	s.clientUpdates <- ClientUpdate{"ALIVE", s.totalData}
 	s.totalData.DataMB = 0
@@ -368,6 +371,9 @@ func (s *SourceControl) broadcastHeartbeat() {
 }
 
 func (s *SourceControl) broadcastStatus() {
+	if s.activeSource != nil {
+		s.status.Running = s.activeSource.Running() // check for source stopping on its own, eg lancero source stops for server state change
+	}
 	s.clientUpdates <- ClientUpdate{"STATUS", s.status}
 }
 

--- a/simulated_data_test.go
+++ b/simulated_data_test.go
@@ -1,6 +1,7 @@
 package dastard
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -230,5 +231,23 @@ func TestSimPulse(t *testing.T) {
 	config.Nchan = 0
 	if err := ps.Configure(&config); err == nil {
 		t.Errorf("SimPulseSource can be configured with 0 channels.")
+	}
+}
+
+func TestErroringSource(t *testing.T) {
+	es := NewErroringSource()
+	ds := DataSource(es)
+	for i := 0; i < 5; i++ {
+		// start the source, wait for it to end due to error, repeat
+		if err := Start(ds); err != nil {
+			t.Fatalf(fmt.Sprintf("%v", err))
+		}
+		es.runDone.Wait()
+		if es.Running() {
+			t.Error("want false")
+		}
+		if es.nBlockingReads != (i+1)*2 {
+			t.Errorf("have %v, want %v", es.nBlockingReads, (i+1)*2)
+		}
 	}
 }


### PR DESCRIPTION
This pull request allows a source to stop due to an internal error, and adds checking for row number, column number and lsync to the lancero source. It may be too strict, but will be easy to modify it that i the case.

It also adds `ErroringSource` to test this behavior.

In the process I found that our tests could fail due to a `PublishSync` failure, and fixed those cases with `defer source.Stop()` in a few places.