### PR TITLE
Noise trigger

### DIFF
--- a/process_data.go
+++ b/process_data.go
@@ -87,6 +87,7 @@ func NewDataStreamProcessor(channelIndex int, broker *TriggerBroker, numberWritt
 	dsp.LastTrigger = math.MinInt64 / 4 // far in the past, but not so far we can't subtract from it
 	dsp.projectors.Reset()              // dsp.projectors is set to zero value
 	dsp.basis.Reset()                   // dsp.basis is set to zero value
+	dsp.inspectStartingAtSample6()      // set up edgeMulti in known state
 	return &dsp
 }
 

--- a/process_data.go
+++ b/process_data.go
@@ -87,7 +87,7 @@ func NewDataStreamProcessor(channelIndex int, broker *TriggerBroker, numberWritt
 	dsp.LastTrigger = math.MinInt64 / 4 // far in the past, but not so far we can't subtract from it
 	dsp.projectors.Reset()              // dsp.projectors is set to zero value
 	dsp.basis.Reset()                   // dsp.basis is set to zero value
-	dsp.inspectStartingAtSample6()      // set up edgeMulti in known state
+	dsp.edgeMultiSetInitialState()      // set up edgeMulti in known state
 	return &dsp
 }
 

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -317,6 +317,7 @@ func (s *SourceControl) WriteControl(config *WriteControlConfig, reply *bool) er
 	return err
 }
 
+// StateLabelConfig is the argument type of SetExperimentStateLabel
 type StateLabelConfig struct {
 	Label string
 }

--- a/triggering.go
+++ b/triggering.go
@@ -52,6 +52,17 @@ type TriggerState struct {
 	// TODO: group source/rx info.
 }
 
+// modify dsp to have it start looking for triggers at sample 6
+// can't be sample 0 because we look back in time by up to 6 samples
+// for kink fit
+func (dsp *DataStreamProcessor) inspectStartingAtSample6() {
+	dsp.edgeMultiILastInspected = -math.MaxInt64 / 4
+	dsp.edgeMultiState = verifying
+	dsp.edgeMultiILastInspected = 6
+	dsp.LastEdgeMultiTrigger = -math.MaxInt64 / 4
+	dsp.edgeMultiIPotential = 6
+}
+
 // create a record using dsp.NPresamples and dsp.NSamples
 func (dsp *DataStreamProcessor) triggerAt(segment *DataSegment, i int) *DataRecord {
 	record := dsp.triggerAtSpecificSamples(segment, i, dsp.NPresamples, dsp.NSamples)

--- a/triggering.go
+++ b/triggering.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"gonum.org/v1/gonum/mat"
 )
 
@@ -319,10 +318,10 @@ func (dsp *DataStreamProcessor) edgeMultiTriggerComputeAppend(records []*DataRec
 		}
 	}
 	if dsp.EdgeMultiNoise {
-		fmt.Println("triggerInds")
-		spew.Dump(triggerInds)
-		fmt.Printf("iLast %v, iFirst %v, dsp.EdgeMultiNoise %v, segment.firstFramenum %v, len(raw) %v, dsp.LastEdgeMultiTrigger %v\n",
-			iLast, iFirst, dsp.EdgeMultiNoise, segment.firstFramenum, len(raw), dsp.LastEdgeMultiTrigger)
+		// fmt.Println("triggerInds")
+		// spew.Dump(triggerInds)
+		// fmt.Printf("iLast %v, iFirst %v, dsp.EdgeMultiNoise %v, segment.firstFramenum %v, len(raw) %v, dsp.LastEdgeMultiTrigger %v\n",
+		// iLast, iFirst, dsp.EdgeMultiNoise, segment.firstFramenum, len(raw), dsp.LastEdgeMultiTrigger)
 		// AutoTrigger
 		if dsp.EdgeMultiNoise && iLast >= iFirst {
 			delaySamples := roundint(dsp.AutoDelay.Seconds() * dsp.SampleRate)
@@ -338,45 +337,45 @@ func (dsp *DataStreamProcessor) edgeMultiTriggerComputeAppend(records []*DataRec
 
 			// dsp.LastTrigger stores the frame of the last trigger found by the most recent invocation of TriggerData
 			nextPotentialTrig := int(dsp.LastEdgeMultiTrigger-segment.firstFramenum) + delaySamples
-			fmt.Printf("nextPotentialTrig %v = dsp.LastEdgeMultiTrigger %v - segment.firstFramenum %v + delaySamples %v\n",
-				nextPotentialTrig, dsp.LastEdgeMultiTrigger, segment.firstFramenum, delaySamples)
+			// fmt.Printf("nextPotentialTrig %v = dsp.LastEdgeMultiTrigger %v - segment.firstFramenum %v + delaySamples %v\n",
+			// nextPotentialTrig, dsp.LastEdgeMultiTrigger, segment.firstFramenum, delaySamples)
 			if nextPotentialTrig < dsp.NPresamples+1 {
 				nextPotentialTrig = dsp.NPresamples + 1
 			}
 
 			// Loop through all potential trigger times.
 			lastSampleOfNextPotentialTrig := nextPotentialTrig + dsp.NSamples - dsp.NPresamples - 1
-			fmt.Println("lastSampleOfNextPotentialTrig", lastSampleOfNextPotentialTrig, "lastIThatCantEdgeTrigger", lastIThatCantEdgeTrigger)
+			// fmt.Println("lastSampleOfNextPotentialTrig", lastSampleOfNextPotentialTrig, "lastIThatCantEdgeTrigger", lastIThatCantEdgeTrigger)
 			for lastSampleOfNextPotentialTrig <= lastIThatCantEdgeTrigger { // can't go all the way to ndata
-				fmt.Printf("iLast %v, iFirst %v, nextPotentialTrig %v, delaySamples %v, nextFoundTrig %v, lastIThatCantEdgeTrigger %v, segment.firstFramenum %v, len(raw) %v\n",
-					iLast, iFirst, nextPotentialTrig, delaySamples, nextFoundTrig, lastIThatCantEdgeTrigger, segment.firstFramenum, len(raw))
-				fmt.Printf("potential trigger at %v, i=%v-%v, FrameIndex=%v-%v\n", nextPotentialTrig,
-					nextPotentialTrig-dsp.NPresamples, nextPotentialTrig+dsp.NSamples-dsp.NPresamples-1,
-					nextPotentialTrig-dsp.NPresamples+int(segment.firstFramenum), nextPotentialTrig+dsp.NSamples-dsp.NPresamples+int(segment.firstFramenum)-1)
+				// fmt.Printf("iLast %v, iFirst %v, nextPotentialTrig %v, delaySamples %v, nextFoundTrig %v, lastIThatCantEdgeTrigger %v, segment.firstFramenum %v, len(raw) %v\n",
+				// 	iLast, iFirst, nextPotentialTrig, delaySamples, nextFoundTrig, lastIThatCantEdgeTrigger, segment.firstFramenum, len(raw))
+				// fmt.Printf("potential trigger at %v, i=%v-%v, FrameIndex=%v-%v\n", nextPotentialTrig,
+				// nextPotentialTrig-dsp.NPresamples, nextPotentialTrig+dsp.NSamples-dsp.NPresamples-1,
+				// nextPotentialTrig-dsp.NPresamples+int(segment.firstFramenum), nextPotentialTrig+dsp.NSamples-dsp.NPresamples+int(segment.firstFramenum)-1)
 				if nextPotentialTrig+dsp.NSamples <= nextFoundTrig {
 					// auto trigger is allowed: no conflict with previously found non-auto triggers
 					newRecord := dsp.triggerAt(segment, nextPotentialTrig)
 					records = append(records, newRecord)
-					fmt.Println("trigger accepted")
+					// fmt.Println("trigger accepted")
 					// fmt.Printf("trigger at %v, i=%v-%v, FrameIndex=%v-%v\n", nextPotentialTrig,
 					// 	newRecord.FirstSampleFrame()-segment.firstFramenum, newRecord.LastSampleFrame()-segment.firstFramenum,
 					// 	newRecord.FirstSampleFrame(), newRecord.LastSampleFrame())
 					nextPotentialTrig += delaySamples
 				} else {
-					fmt.Println("trigger rejected")
+					// fmt.Println("trigger rejected")
 					// auto trigger not allowed: conflict with previously found non-auto triggers
 					nextPotentialTrig = nextFoundTrig + delaySamples
 					idxNextTrig++
 					if nFoundTrigs > idxNextTrig {
-						fmt.Println("increment from next edgeTrigger")
+						// fmt.Println("increment from next edgeTrigger")
 						nextFoundTrig = triggerInds[idxNextTrig]
 					} else {
-						fmt.Println("no more edgeTriggers")
+						// fmt.Println("no more edgeTriggers")
 						nextFoundTrig = math.MaxInt64
 					}
 				}
 				lastSampleOfNextPotentialTrig = nextPotentialTrig + dsp.NSamples - dsp.NPresamples - 1
-				fmt.Println("lastSampleOfNextPotentialTrig", lastSampleOfNextPotentialTrig)
+				// fmt.Println("lastSampleOfNextPotentialTrig", lastSampleOfNextPotentialTrig)
 			}
 			if iLast >= iFirst {
 				dsp.stream.TrimKeepingN(2*dsp.NSamples + 1) // +1 to account for maximum shift from kink model

--- a/triggering.go
+++ b/triggering.go
@@ -211,6 +211,7 @@ func (dsp *DataStreamProcessor) edgeMultiTriggerComputeAppend(records []*DataRec
 					xdataf := make([]float64, 10)
 					ydataf := make([]float64, 10)
 					for j := 0; j < 10; j++ {
+						fmt.Printf("j %v, iPotential %v, j+iPotential-6 %v, i %v\n", j, iPotential, j+iPotential-6, i)
 						xdataf[j] = float64(j + iPotential - 6) // look at samples from i-6 to i+3
 						ydataf[j] = float64(raw[j+iPotential-6])
 					}

--- a/triggering_test.go
+++ b/triggering_test.go
@@ -561,7 +561,7 @@ func TestEdgeMulti(t *testing.T) {
 	_, _ = testTriggerSubroutine(t, rawE, nRepeat, dsp, "EdgeMulti F: dont make records when it is monotone for >= dsp.NSamples", []FrameIndex{})
 
 	dsp.edgeMultiSetInitialState() // call this between each edgeMulti test
-	dsp.edgeMultiState = searching
+	dsp.edgeMultiInternalSearchState = searching
 	dsp.NSamples = 30
 	dsp.NPresamples = 25
 	dsp.EdgeMultiMakeContaminatedRecords = true

--- a/triggering_test.go
+++ b/triggering_test.go
@@ -561,7 +561,6 @@ func TestEdgeMulti(t *testing.T) {
 	_, _ = testTriggerSubroutine(t, rawE, nRepeat, dsp, "EdgeMulti F: dont make records when it is monotone for >= dsp.NSamples", []FrameIndex{})
 
 	dsp.edgeMultiSetInitialState() // call this between each edgeMulti test
-	dsp.edgeMultiInternalSearchState = searching
 	dsp.NSamples = 30
 	dsp.NPresamples = 25
 	dsp.EdgeMultiMakeContaminatedRecords = true
@@ -574,7 +573,7 @@ func TestEdgeMulti(t *testing.T) {
 	}
 	nRepeatG := 20
 	expectG := make([]FrameIndex, 0)
-	for i := 2*dsp.NSamples + 1; i < len(rawG)*nRepeatG-(dsp.NSamples-dsp.NPresamples); i += 2 {
+	for i := dsp.NPresamples + 2; i < len(rawG)*nRepeatG-(dsp.NSamples-dsp.NPresamples); i += 2 {
 		expectG = append(expectG, FrameIndex(i))
 	}
 	_, _ = testTriggerSubroutine(t, rawG, nRepeatG, dsp, "EdgeMulti G: make lots of contaminated records", expectG)

--- a/triggering_test.go
+++ b/triggering_test.go
@@ -550,7 +550,6 @@ func TestEdgeMulti(t *testing.T) {
 		}
 		kinkListFrameIndexE[i] = FrameIndex(kint)
 	}
-	fmt.Println("rawE", rawE)
 	dsp.edgeMultiSetInitialState() // call this between each edgeMulti test
 	nRepeatE := 3
 	// here we attempt to trigger around a segment boundary
@@ -598,15 +597,16 @@ func TestEdgeMulti(t *testing.T) {
 	_, _ = testTriggerSubroutine(t, rawI, nRepeatI, dsp, "EdgeMulti I: EdgeMultiNoise basic, segments shorter than records",
 		[]FrameIndex{200, 300, 400, 500, 600, 700, 800, 900})
 
-	// dsp.NSamples = 10
-	// dsp.NPresamples = 5
-	// dsp.EdgeLevel = 1
-	// nRepeatJ := 5
-	// rawJ := make([]RawType, 40)
-	// rawJ[20] = 1
-	// dsp.LastEdgeMultiTrigger = 0
-	// _, _ = testTriggerSubroutine(t, rawI, nRepeatI, dsp, "EdgeMulti J: EdgeMultiNoise basic, segments shorter than records",
-	// 	[]FrameIndex{100, 200, 300, 400, 500, 600, 700, 800, 900})
+	dsp.NSamples = 10
+	dsp.NPresamples = 5
+	dsp.EdgeLevel = 1
+	nRepeatJ := 2
+	rawJ := make([]RawType, 100)
+	rawJ[50] = 1
+	dsp.edgeMultiSetInitialState() // call this between each edgeMulti test
+	dsp.LastEdgeMultiTrigger = 20  // make first noise trigger a round number
+	_, _ = testTriggerSubroutine(t, rawJ, nRepeatJ, dsp, "EdgeMulti J: EdgeMultiNoise avoiding edge triggers",
+		[]FrameIndex{30, 40, 60, 70, 80, 90, 100, 110, 120, 130, 140, 160, 170, 180, 190})
 
 }
 

--- a/triggering_test.go
+++ b/triggering_test.go
@@ -462,17 +462,6 @@ func TestEdgeLevelInteraction(t *testing.T) {
 	testTriggerSubroutine(t, raw, nRepeat, dsp, "Edge + Level 6", []FrameIndex{1000, 6000, 9050})
 }
 
-// modify dsp to have it start looking for triggers at sample 6
-// can't be sample 0 because we look back in time by up to 6 samples
-// for kink fit
-func inspectStartingAtSample6(dsp *DataStreamProcessor) {
-	dsp.edgeMultiILastInspected = -math.MaxInt64 / 4
-	dsp.edgeMultiState = verifying
-	dsp.edgeMultiILastInspected = 6
-	dsp.LastEdgeMultiTrigger = -math.MaxInt64 / 4
-	dsp.edgeMultiIPotential = 6
-}
-
 func TestEdgeMulti(t *testing.T) {
 	const nchan = 1
 
@@ -513,14 +502,14 @@ func TestEdgeMulti(t *testing.T) {
 	nRepeat := 1
 	testTriggerSubroutine(t, raw, nRepeat, dsp, "EdgeMulti A: level too high", []FrameIndex{})
 	dsp.EdgeLevel = 1
-	inspectStartingAtSample6(dsp) // call this between each edgeMulti test
+	dsp.inspectStartingAtSample6() // call this between each edgeMulti test
 	// here we will find all triggers in trigInds, but triggers that are too short are not recordized
 	// the kinks that occur at fractional samples will end up the rounded value
 	// ideally 200.1 should trigger at 201, but since we only check k values in 0.5 step increments, we miss it
 	// my tests suggest testing at 0.5 step increments is ok on real data (eg a set of data from the Raven backup array test in 2018)
 	testTriggerSubroutine(t, raw, nRepeat, dsp, "EdgeMulti B: make only full length records", []FrameIndex{100, 200, 301, 401, 700})
 	dsp.EdgeMultiMakeContaminatedRecords = true
-	inspectStartingAtSample6(dsp) // call this between each edgeMulti test
+	dsp.inspectStartingAtSample6() // call this between each edgeMulti test
 
 	// here we will find all triggers in trigInds, and contaminated records will be created
 	primaries, _ := testTriggerSubroutine(t, raw, nRepeat, dsp, "EdgeMulti C: MakeContaminatedRecords", []FrameIndex{100, 200, 301, 401, 460, 500, 540, 700})
@@ -531,7 +520,7 @@ func TestEdgeMulti(t *testing.T) {
 	}
 	dsp.EdgeMultiMakeContaminatedRecords = false
 	dsp.EdgeMultiMakeShortRecords = true
-	inspectStartingAtSample6(dsp) // call this between each edgeMulti test
+	dsp.inspectStartingAtSample6() // call this between each edgeMulti test
 	// here we will find all triggers in trigInds, and short records will be created
 	primaries, _ = testTriggerSubroutine(t, raw, nRepeat, dsp, "EdgeMulti D: MakeShortRecords", []FrameIndex{100, 200, 301, 401, 460, 500, 540, 700})
 	///                                                                 lengths   100, 100, 100, 100, 49,  40,  50,  100
@@ -562,17 +551,17 @@ func TestEdgeMulti(t *testing.T) {
 		kinkListFrameIndexE[i] = FrameIndex(kint)
 	}
 	fmt.Println("rawE", rawE)
-	inspectStartingAtSample6(dsp) // call this between each edgeMulti test
+	dsp.inspectStartingAtSample6() // call this between each edgeMulti test
 	nRepeatE := 3
 	// here we attempt to trigger around a segment boundary
 	_, _ = testTriggerSubroutine(t, rawE, nRepeatE, dsp, "EdgeMulti E: handling segment boundary", []FrameIndex{945, 1945})
 
 	dsp.NSamples = 15
 	dsp.NPresamples = 6
-	inspectStartingAtSample6(dsp) // call this between each edgeMulti test
+	dsp.inspectStartingAtSample6() // call this between each edgeMulti test
 	_, _ = testTriggerSubroutine(t, rawE, nRepeat, dsp, "EdgeMulti F: dont make records when it is monotone for >= dsp.NSamples", []FrameIndex{})
 
-	inspectStartingAtSample6(dsp) // call this between each edgeMulti test
+	dsp.inspectStartingAtSample6() // call this between each edgeMulti test
 	dsp.edgeMultiState = searching
 	dsp.NSamples = 30
 	dsp.NPresamples = 25

--- a/triggering_test.go
+++ b/triggering_test.go
@@ -363,12 +363,12 @@ func testTriggerSubroutine(t *testing.T, raw []RawType, nRepeat int, dsp *DataSt
 	}
 	if len(primaries) != len(expectedFrames) {
 		t.Errorf("%s: have %v triggers, want %v triggers", trigname, len(primaries), len(expectedFrames))
-		fmt.Print("found ")
+		fmt.Print("have ")
 		for _, p := range primaries {
 			fmt.Printf("%v,", p.trigFrame)
 		}
 		fmt.Println()
-		fmt.Print("found ")
+		fmt.Print("want ")
 		for _, v := range expectedFrames {
 			fmt.Printf("%v,", v)
 		}
@@ -462,6 +462,15 @@ func TestEdgeLevelInteraction(t *testing.T) {
 	testTriggerSubroutine(t, raw, nRepeat, dsp, "Edge + Level 6", []FrameIndex{1000, 6000, 9050})
 }
 
+// modify dsp to have it start looking for triggers at sample 1
+// can't be sample 0 because we look back in time by one sample
+func inspectStartingAtSample1(dsp *DataStreamProcessor) {
+	dsp.edgeMultiILastInspected = -math.MaxInt64 / 4
+	dsp.edgeMultiState = verifying
+	dsp.edgeMultiILastInspected = 0
+	dsp.LastEdgeMultiTrigger = -math.MaxInt64 / 4
+}
+
 func TestEdgeMulti(t *testing.T) {
 	const nchan = 1
 
@@ -502,14 +511,15 @@ func TestEdgeMulti(t *testing.T) {
 	nRepeat := 1
 	testTriggerSubroutine(t, raw, nRepeat, dsp, "EdgeMulti A: level too high", []FrameIndex{})
 	dsp.EdgeLevel = 1
-	dsp.LastEdgeMultiTrigger = 0 // need to reset this each time
+	inspectStartingAtSample1(dsp) // call this between each edgeMulti test
 	// here we will find all triggers in trigInds, but triggers that are too short are not recordized
 	// the kinks that occur at fractional samples will end up the rounded value
 	// ideally 200.1 should trigger at 201, but since we only check k values in 0.5 step increments, we miss it
 	// my tests suggest testing at 0.5 step increments is ok on real data (eg a set of data from the Raven backup array test in 2018)
 	testTriggerSubroutine(t, raw, nRepeat, dsp, "EdgeMulti B: make only full length records", []FrameIndex{100, 200, 301, 401, 700})
 	dsp.EdgeMultiMakeContaminatedRecords = true
-	dsp.LastEdgeMultiTrigger = 0 // need to reset this each time
+	inspectStartingAtSample1(dsp) // call this between each edgeMulti test
+
 	// here we will find all triggers in trigInds, and contaminated records will be created
 	primaries, _ := testTriggerSubroutine(t, raw, nRepeat, dsp, "EdgeMulti C: MakeContaminatedRecords", []FrameIndex{100, 200, 301, 401, 460, 500, 540, 700})
 	for _, record := range primaries {
@@ -519,7 +529,7 @@ func TestEdgeMulti(t *testing.T) {
 	}
 	dsp.EdgeMultiMakeContaminatedRecords = false
 	dsp.EdgeMultiMakeShortRecords = true
-	dsp.LastEdgeMultiTrigger = 0 // need to reset this each time
+	inspectStartingAtSample1(dsp) // call this between each edgeMulti test
 	// here we will find all triggers in trigInds, and short records will be created
 	primaries, _ = testTriggerSubroutine(t, raw, nRepeat, dsp, "EdgeMulti D: MakeShortRecords", []FrameIndex{100, 200, 301, 401, 460, 500, 540, 700})
 	///                                                                 lengths   100, 100, 100, 100, 49,  40,  50,  100
@@ -527,7 +537,7 @@ func TestEdgeMulti(t *testing.T) {
 	for i, record := range primaries {
 		if len(record.data) != expectLengths[i] {
 			//if true {
-			t.Errorf("EdgeMulti D record %v: expect_len %v, len %v, presamples %v, trigFrame %v, %v:%v", i, expectLengths[i],
+			t.Errorf("EdgeMulti D record %v: expect len %v, have len %v, presamples %v, trigFrame %v, %v:%v", i, expectLengths[i],
 				len(record.data), record.presamples, record.trigFrame, int(record.trigFrame)-record.presamples, int(record.trigFrame)-record.presamples+len(record.data)-1)
 		}
 	}
@@ -550,52 +560,52 @@ func TestEdgeMulti(t *testing.T) {
 		kinkListFrameIndexE[i] = FrameIndex(kint)
 	}
 	// fmt.Println("rawE", rawE)
-	dsp.LastEdgeMultiTrigger = 0 // need to reset this each time
-	nRepeatE := 3
-	// here we attempt to trigger around a segment boundary
-	_, _ = testTriggerSubroutine(t, rawE, nRepeatE, dsp, "EdgeMulti E: handling segment boundary", []FrameIndex{945, 1945})
+	// inspectStartingAtSample1(dsp) // call this between each edgeMulti test
+	// nRepeatE := 3
+	// // here we attempt to trigger around a segment boundary
+	// _, _ = testTriggerSubroutine(t, rawE, nRepeatE, dsp, "EdgeMulti E: handling segment boundary", []FrameIndex{945, 1945})
+	//
+	// dsp.NSamples = 15
+	// dsp.NPresamples = 6
+	// dsp.LastEdgeMultiTrigger = -math.MaxInt64 / 4 // need to reset this each time
+	// dsp.edgeMultiState = searching                // need to reset this after E
+	// _, _ = testTriggerSubroutine(t, rawE, nRepeat, dsp, "EdgeMulti F: dont make records when it is monotone for >= dsp.NSamples", []FrameIndex{})
 
-	dsp.NSamples = 15
-	dsp.NPresamples = 6
-	dsp.LastEdgeMultiTrigger = 0   // need to reset this each time
-	dsp.edgeMultiState = searching // need to reset this after E
-	_, _ = testTriggerSubroutine(t, rawE, nRepeat, dsp, "EdgeMulti F: dont make records when it is monotone for >= dsp.NSamples", []FrameIndex{})
+	// inspectStartingAtSample1(dsp) // call this between each edgeMulti test
+	// dsp.NSamples = 30
+	// dsp.NPresamples = 25
+	// dsp.EdgeMultiMakeContaminatedRecords = true
+	// dsp.EdgeLevel = 0
+	// dsp.EdgeMultiVerifyNMonotone = 0
+	//
+	// rawG := make([]RawType, 10)
+	// for i := 0; i < len(rawG); i++ {
+	// 	rawG[i] = RawType(i % 2)
+	// }
+	// nRepeatG := 20
+	// expectG := make([]FrameIndex, 0)
+	// for i := dsp.NPresamples + 2; i < len(rawG)*nRepeatG-(dsp.NSamples-dsp.NPresamples); i += 2 {
+	// 	expectG = append(expectG, FrameIndex(i))
+	// }
+	//
+	// _, _ = testTriggerSubroutine(t, rawG, nRepeatG, dsp, "EdgeMulti G: make lots of contaminated records", expectG)
 
-	dsp.LastEdgeMultiTrigger = 0 // need to reset this each time
-	dsp.NSamples = 30
-	dsp.NPresamples = 25
-	dsp.EdgeMultiMakeContaminatedRecords = true
-	dsp.EdgeLevel = 0
-	dsp.EdgeMultiVerifyNMonotone = 0
-
-	rawG := make([]RawType, 10)
-	for i := 0; i < len(rawG); i++ {
-		rawG[i] = RawType(i % 2)
-	}
-	nRepeatG := 20
-	expectG := make([]FrameIndex, 0)
-	for i := dsp.NPresamples + 2; i < len(rawG)*nRepeatG-(dsp.NSamples-dsp.NPresamples); i += 2 {
-		expectG = append(expectG, FrameIndex(i))
-	}
-
-	_, _ = testTriggerSubroutine(t, rawG, nRepeatG, dsp, "EdgeMulti G: make lots of contaminated records", expectG)
-
-	dsp.EdgeMulti = true
-	dsp.EdgeMultiNoise = true
-	dsp.EdgeLevel = math.MaxInt32 // don't ever add to TriggerInds
-	dsp.NSamples = 100
-	dsp.NPresamples = 50
-	dsp.LastEdgeMultiTrigger = 0
-	dsp.edgeMultiState = searching
-	nRepeatH := 2
-	rawH := make([]RawType, 500)
-	_, _ = testTriggerSubroutine(t, rawH, nRepeatH, dsp, "EdgeMulti H: EdgeMultiNoise basic", []FrameIndex{100, 200, 300, 400, 500, 600, 700, 800, 900})
-
-	nRepeatI := 100
-	rawI := make([]RawType, 10)
-	dsp.LastEdgeMultiTrigger = -100
-	_, _ = testTriggerSubroutine(t, rawI, nRepeatI, dsp, "EdgeMulti I: EdgeMultiNoise basic, segments shorter than records",
-		[]FrameIndex{100, 200, 300, 400, 500, 600, 700, 800, 900})
+	// dsp.EdgeMulti = true
+	// dsp.EdgeMultiNoise = true
+	// dsp.EdgeLevel = math.MaxInt32 // don't ever add to TriggerInds
+	// dsp.NSamples = 100
+	// dsp.NPresamples = 50
+	// dsp.LastEdgeMultiTrigger = 0
+	// dsp.edgeMultiState = searching
+	// nRepeatH := 2
+	// rawH := make([]RawType, 500)
+	// _, _ = testTriggerSubroutine(t, rawH, nRepeatH, dsp, "EdgeMulti H: EdgeMultiNoise basic", []FrameIndex{100, 200, 300, 400, 500, 600, 700, 800, 900})
+	//
+	// nRepeatI := 25
+	// rawI := make([]RawType, 40)
+	// dsp.LastEdgeMultiTrigger = 0
+	// _, _ = testTriggerSubroutine(t, rawI, nRepeatI, dsp, "EdgeMulti I: EdgeMultiNoise basic, segments shorter than records",
+	// 	[]FrameIndex{100, 200, 300, 400, 500, 600, 700, 800, 900})
 
 }
 


### PR DESCRIPTION
This implements a noise trigger based on Edge Multi, and also adds a big old comment box next to the Experimental edge Multi settings about how it's easy to get confused because the behavior is quite different from edge triggers.

The algorithm for the noise trigger is roughly
1. look for edgeMulti possible triggers (eg things that meet both the difference threshold and the consecutive rising samples threshold)
2. look for auto triggers that are far enough away from 1
3. generate records based on 2 (don't generate records based on 1)

This was WAY harder than I expected, but it seems to work well.