### PR TITLE
Get lsync right attempt

### DIFF
--- a/data_source.go
+++ b/data_source.go
@@ -48,6 +48,7 @@ type DataSource interface {
 	ProcessSegments() error
 	RunDoneAdd()
 	RunDoneDone()
+	ShouldAutoRestart() bool
 }
 
 // Wait returns when the source run is done, aka the source is stopped
@@ -55,6 +56,11 @@ func (ds *AnySource) Wait() error {
 	// fmt.Println("ds.Wait")
 	ds.runDone.Wait()
 	return nil
+}
+
+// Return true if source should be auto-restarted after an error (AnySource default implementation returns false)
+func (ds *AnySource) ShouldAutoRestart() bool {
+	return ds.shouldAutoRestart
 }
 
 // ConfigureMixFraction provides a default implementation for all non-lancero sources that
@@ -169,6 +175,7 @@ type AnySource struct {
 	abortSelf    chan struct{} // This can signal the Run() goroutine to stop
 	broker       *TriggerBroker
 	// publishSync  *PublishSync
+	shouldAutoRestart   bool // used to tell SourceControl to try to restart this source after an error
 	noProcess           bool // Set true only for testing.
 	heartbeats          chan Heartbeat
 	segments            []DataSegment

--- a/lancero_source.go
+++ b/lancero_source.go
@@ -91,12 +91,13 @@ func contains(s []*LanceroDevice, e *LanceroDevice) bool {
 // For now, we'll make the FiberMask equal for all cards. That need not
 // be permanent, but I do think ClockMhz is necessarily the same for all cards.
 type LanceroSourceConfig struct {
-	FiberMask      uint32
-	ClockMhz       int
-	Nsamp          int
-	CardDelay      []int
-	ActiveCards    []int
-	AvailableCards []int
+	FiberMask         uint32
+	ClockMhz          int
+	Nsamp             int
+	CardDelay         []int
+	ActiveCards       []int
+	AvailableCards    []int
+	ShouldAutoRestart bool
 }
 
 // Configure sets up the internal buffers with given size, speed, and min/max.
@@ -111,6 +112,7 @@ func (ls *LanceroSource) Configure(config *LanceroSourceConfig) error {
 
 	ls.active = make([]*LanceroDevice, 0)
 	ls.clockMhz = config.ClockMhz
+	ls.shouldAutoRestart = config.ShouldAutoRestart
 	for i, c := range config.ActiveCards {
 		dev := ls.devices[c]
 		if dev == nil {

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -289,6 +289,9 @@ func (s *SourceControl) handlePosibleStoppedSource() {
 		s.status.Running = false
 		s.isSourceActive = false
 		s.clientUpdates <- ClientUpdate{"STATUS", s.status}
+		if s.ActiveSource.ShouldAutoRestart() {
+			log.Println("dastard is aware it should AutoRestart, but it's not implemented yet")
+		}
 	}
 }
 


### PR DESCRIPTION
- refactor how lsync is calculated. 
- Uses the timeFix from `AvailableBuffers` instead of waittime from `Wait`
- collects 200 ms worth of info for calculating lsync
- stops using more memory after ncol/nrow is found
- tested on 687raven i got lsync right every time until the lancero card stopped working an I needed to reboot (10 times approx), seems like an improvement to me

- adds some progress towards an AutoRestart button for lancero source