### PR TITLE
add ReadComment to rpc API

### DIFF
--- a/rpc_server.go
+++ b/rpc_server.go
@@ -3,6 +3,7 @@ package dastard
 import (
 	"encoding/base64"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net"
 	"net/rpc"
@@ -366,6 +367,26 @@ func (s *SourceControl) WriteComment(comment *string, reply *bool) error {
 			fp.WriteString("\n")
 		}
 	}
+	return nil
+}
+
+// ReadComment reads the contents of comment.txt if it exists, otherwise returns err
+func (s *SourceControl) ReadComment(zero *int, reply *string) error {
+	if !s.isSourceActive {
+		return fmt.Errorf("cant read comment with no active source")
+	} else if *zero != 0 {
+		return fmt.Errorf("please pass an the value 0, as it will be ignored, you passed %v", zero)
+	}
+	ws := s.ActiveSource.ComputeWritingState()
+	if !ws.Active {
+		return fmt.Errorf("cant read comment when not activley writing")
+	}
+	commentFilename := path.Join(filepath.Dir(ws.FilenamePattern), "comment.txt")
+	b, err := ioutil.ReadFile(commentFilename)
+	if err != nil {
+		return err
+	}
+	*reply = string(b)
 	return nil
 }
 

--- a/rpc_server_test.go
+++ b/rpc_server_test.go
@@ -225,6 +225,16 @@ func TestServer(t *testing.T) {
 	if err1 := client.Call("SourceControl.WriteComment", &comment, &okay); err1 != nil {
 		t.Error("SourceControl.WriteComment error while writing:", err1)
 	}
+	if true { // prevent variables from persisting
+		var zero *int
+		var reply *string
+		if err1 := client.Call("SourceControl.ReadComment", &zero, &reply); err1 != nil {
+			t.Error("SourceControl.ReadComment error:", err1)
+		}
+		if *reply != "hello\n" {
+			t.Errorf("want %q, have %q", "hello\n", *reply)
+		}
+	}
 	stateLabelArg := StateLabelConfig{Label: "testlabel"}
 	if err1 := client.Call("SourceControl.SetExperimentStateLabel", &stateLabelArg, &okay); err1 != nil {
 		t.Error(err1)


### PR DESCRIPTION
add ReadComment to rpc API

allow dastard-commander to write a comment, then modify that same comment on a subsequent click