### PR TITLE
Fix record length 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ tstfile
 *.off
 dastard
 !dastard/
+.idea

--- a/data_source_test.go
+++ b/data_source_test.go
@@ -71,7 +71,7 @@ func TestWritingFiles(t *testing.T) {
 
 	ds := AnySource{nchan: 4}
 	ds.rowColCodes = make([]RowColCode, ds.nchan)
-	ds.PrepareRun()
+	ds.PrepareRun(256, 1024)
 	defer ds.Stop()
 	config := &WriteControlConfig{Request: "Pause", Path: tmp, WriteLJH22: true}
 	for _, request := range []string{"Pause", "Unpause", "Stop"} {

--- a/lancero_test.go
+++ b/lancero_test.go
@@ -117,7 +117,7 @@ func TestNoHardwareSource(t *testing.T) {
 		t.Error("LanceroSource.Configure fails:", err)
 	}
 
-	if err := Start(source, nil); err != nil {
+	if err := Start(source, nil, 256, 1024); err != nil {
 		source.Stop()
 		t.Fatal(err)
 	}

--- a/process_data.go
+++ b/process_data.go
@@ -67,17 +67,15 @@ func (dsp *DataStreamProcessor) HasProjectors() bool {
 }
 
 // NewDataStreamProcessor creates and initializes a new DataStreamProcessor.
-func NewDataStreamProcessor(channelIndex int, broker *TriggerBroker) *DataStreamProcessor {
+func NewDataStreamProcessor(channelIndex int, broker *TriggerBroker, NPresamples int, NSamples int) *DataStreamProcessor {
 	data := make([]RawType, 0, 1024)
 	framesPerSample := 1
 	firstFrame := FrameIndex(0)
 	firstTime := time.Now()
 	period := time.Duration(1 * time.Millisecond) // TODO: figure out what this ought to be, or make an argument
 	stream := NewDataStream(data, framesPerSample, firstFrame, firstTime, period)
-	nsamp := 1024 // TODO: figure out what this ought to be, or make an argument
-	npre := 256   // TODO: figure out what this ought to be, or make an argument
 	dsp := DataStreamProcessor{channelIndex: channelIndex, Broker: broker,
-		stream: *stream, NSamples: nsamp, NPresamples: npre,
+		stream: *stream, NSamples: NSamples, NPresamples: NPresamples,
 	}
 	dsp.LastTrigger = math.MinInt64 / 4 // far in the past, but not so far we can't subtract from it
 	dsp.projectors.Reset()              // dsp.projectors is set to zero value

--- a/process_data_test.go
+++ b/process_data_test.go
@@ -176,7 +176,7 @@ func TestDataSignedness(t *testing.T) {
 	// Make sure PrepareRun produces the right answers.
 	var ts TriangleSource
 	ts.nchan = 4
-	ts.PrepareRun()
+	ts.PrepareRun(256, 1024)
 	defer ts.Stop()
 	for i, dsp := range ts.processors {
 		expect := false
@@ -192,7 +192,7 @@ func TestDataSignedness(t *testing.T) {
 	for i := 0; i < ls.nchan; i += 2 {
 		ls.signed[i] = true
 	}
-	ls.PrepareRun()
+	ls.PrepareRun(256, 1024)
 	defer ls.Stop()
 	for i, dsp := range ls.processors {
 		expect := (i % 2) == 0
@@ -206,7 +206,9 @@ func TestDataSignedness(t *testing.T) {
 	data := make([]RawType, len(errsig))
 	copy(data, errsig)
 	seg := &DataSegment{rawData: data}
-	dsp := NewDataStreamProcessor(0, nil)
+	NPresamples := 256
+	NSamples := 1024
+	dsp := NewDataStreamProcessor(0, nil, NPresamples, NSamples)
 	dsp.DecimateLevel = 2
 	dsp.Decimate = true
 	dsp.DecimateAvgMode = true

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -227,7 +227,7 @@ func (s *SourceControl) ConfigurePulseLengths(sizes SizeObject, reply *bool) err
 		return fmt.Errorf("No source is active")
 	}
 	if s.status.Npresamp == sizes.Npre && s.status.Nsamples == sizes.Nsamp {
-		return nil // No change requested
+		return fmt.Errorf("requested PulseLengths %v,%v identical to current pulse lengths %v,%v", sizes.Npre, sizes.Nsamp, s.status.Npresamp, s.status.Nsamples)
 	}
 	if s.ActiveSource.ComputeWritingState().Active {
 		return fmt.Errorf("Stop writing before changing record lengths")
@@ -279,18 +279,12 @@ func (s *SourceControl) Start(sourceName *string, reply *bool) error {
 
 	log.Printf("Starting data source named %s\n", *sourceName)
 	s.status.Running = true
-	if err := Start(s.ActiveSource, s.queuedRequests); err != nil {
+	if err := Start(s.ActiveSource, s.queuedRequests, s.status.Npresamp, s.status.Nsamples); err != nil {
 		s.status.Running = false
 		s.isSourceActive = false
 		return err
 	}
 	s.isSourceActive = true
-	sizes := SizeObject{Npre: s.status.Npresamp, Nsamp: s.status.Nsamples}
-	var replyIgnored bool
-	// Npresamp and Nsamples are properties of the DataStreamProcessor
-	// they are hardcoded in NewDataStreamProcessor, which is called in PrepareRun, which is called in Start
-	// so rather than chain through arguments, I just call ConfigurePulseLengths after Start
-	s.ConfigurePulseLengths(sizes, &replyIgnored)
 	s.status.Nchannels = s.ActiveSource.Nchan()
 	if ls, ok := s.ActiveSource.(*LanceroSource); ok {
 		s.status.Ncol = make([]int, ls.ncards)

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -227,7 +227,7 @@ func (s *SourceControl) ConfigurePulseLengths(sizes SizeObject, reply *bool) err
 		return fmt.Errorf("No source is active")
 	}
 	if s.status.Npresamp == sizes.Npre && s.status.Nsamples == sizes.Nsamp {
-		return fmt.Errorf("requested PulseLengths %v,%v identical to current pulse lengths %v,%v", sizes.Npre, sizes.Nsamp, s.status.Npresamp, s.status.Nsamples)
+		return nil // no change requested
 	}
 	if s.ActiveSource.ComputeWritingState().Active {
 		return fmt.Errorf("Stop writing before changing record lengths")

--- a/simulated_data_test.go
+++ b/simulated_data_test.go
@@ -24,7 +24,7 @@ func TestTriangle(t *testing.T) {
 		t.Errorf("TriangleSource.Running() says true before first start.")
 	}
 
-	if err := Start(ds, nil); err != nil {
+	if err := Start(ds, nil, 256, 1024); err != nil {
 		t.Fatalf("TriangleSource could not be started")
 	}
 	if len(ts.processors) != config.Nchan {
@@ -78,7 +78,7 @@ func TestTriangle(t *testing.T) {
 	}
 
 	// Start again
-	if err := Start(ds, nil); err != nil {
+	if err := Start(ds, nil, 256, 1024); err != nil {
 		t.Fatalf("TriangleSource could not be started, %s", err.Error())
 	}
 	if !ds.Running() {
@@ -87,7 +87,7 @@ func TestTriangle(t *testing.T) {
 	if err := ts.Configure(&config); err == nil {
 		t.Errorf("TriangleSource can be configured with even though it's running, want error.")
 	}
-	if err := Start(ds, nil); err == nil {
+	if err := Start(ds, nil, 256, 1024); err == nil {
 		t.Errorf("Start(TriangleSource) was allowed when source was running, want error.")
 	}
 	time.Sleep(100 * time.Millisecond)
@@ -97,7 +97,7 @@ func TestTriangle(t *testing.T) {
 	}
 
 	// Start a third time
-	if err := Start(ds, nil); err != nil {
+	if err := Start(ds, nil, 256, 1024); err != nil {
 		t.Fatalf("TriangleSource could not be started")
 	}
 	// Check that we can alter the record length
@@ -178,8 +178,15 @@ func TestSimPulse(t *testing.T) {
 		t.Errorf("SimPulseSource.Running() says true before first start.")
 	}
 
-	if err := Start(ds, nil); err != nil {
+	if err := Start(ds, nil, 123, 321); err != nil {
 		t.Fatalf("SimPulseSource could not be started")
+	}
+	Npresamp, Nsamples, err1 := ds.getPulseLengths()
+	if err1 != nil {
+		t.Error(err1)
+	}
+	if Npresamp != 123 || Nsamples != 321 {
+		t.Errorf("Npresample want 123, have %v. Nsamples want 321, have %v", Npresamp, Nsamples)
 	}
 	if len(ps.processors) != config.Nchan {
 		t.Errorf("SimPulseSource.Ouputs() returns %d channels, want %d", len(ps.processors), config.Nchan)
@@ -227,17 +234,21 @@ func TestSimPulse(t *testing.T) {
 	if ds.Running() {
 		t.Errorf("SimPulseSource.Running() says true before started.")
 	}
-	if err := Start(ds, nil); err != nil {
+	if err := Start(ds, nil, 256, 1024); err != nil {
 		t.Fatalf("SimPulseSource could not be started")
+	}
+	Npresamp, Nsamples, err2 := ds.getPulseLengths()
+	if err2 != nil {
+		t.Error(err2)
+	}
+	if Npresamp != 256 || Nsamples != 1024 {
+		t.Errorf("Npresample want 123, have %v. Nsamples want 321, have %v", Npresamp, Nsamples)
 	}
 	if !ds.Running() {
 		t.Errorf("SimPulseSource.Running() says false after started.")
 	}
 	if err := ps.Configure(&config); err == nil {
 		t.Errorf("SimPulseSource can be configured with even though it's running, want error.")
-	}
-	if err := Start(ds, nil); err == nil {
-		t.Errorf("Start(SimPulseSource) was allowed when source was running, want error.")
 	}
 	ds.Stop()
 	if ds.Running() {
@@ -256,7 +267,7 @@ func TestErroringSource(t *testing.T) {
 	ds := DataSource(es)
 	for i := 0; i < 5; i++ {
 		// 	// start the source, wait for it to end due to error, repeat
-		if err := Start(ds, nil); err != nil {
+		if err := Start(ds, nil, 256, 1024); err != nil {
 			t.Fatalf(fmt.Sprintf("Could not start ErroringSource: i=%v, err=%v", i, err))
 		}
 		es.RunDoneWait()

--- a/triggering_test.go
+++ b/triggering_test.go
@@ -203,7 +203,9 @@ func TestLongRecords(t *testing.T) {
 		{1000, 10000, 10001},
 	}
 	for _, test := range tests {
-		dsp := NewDataStreamProcessor(0, broker)
+		NPresamples := 256
+		NSamples := 1024
+		dsp := NewDataStreamProcessor(0, broker, NPresamples, NSamples)
 		dsp.NPresamples = test.npre
 		dsp.NSamples = test.nsamp
 		dsp.SampleRate = 100000.0
@@ -246,7 +248,9 @@ func TestSingles(t *testing.T) {
 	broker := NewTriggerBroker(nchan)
 	go broker.Run()
 	defer broker.Stop()
-	dsp := NewDataStreamProcessor(0, broker)
+	NPresamples := 256
+	NSamples := 1024
+	dsp := NewDataStreamProcessor(0, broker, NPresamples, NSamples)
 	nRepeat := 1
 
 	const bigval = 8000
@@ -410,7 +414,9 @@ func TestEdgeLevelInteraction(t *testing.T) {
 	broker := NewTriggerBroker(nchan)
 	go broker.Run()
 	defer broker.Stop()
-	dsp := NewDataStreamProcessor(0, broker)
+	NPresamples := 256
+	NSamples := 1024
+	dsp := NewDataStreamProcessor(0, broker, NPresamples, NSamples)
 	nRepeat := 1
 
 	const bigval = 8000
@@ -468,7 +474,9 @@ func TestEdgeMulti(t *testing.T) {
 	broker := NewTriggerBroker(nchan)
 	go broker.Run()
 	defer broker.Stop()
-	dsp := NewDataStreamProcessor(0, broker)
+	NPresamples := 256
+	NSamples := 1024
+	dsp := NewDataStreamProcessor(0, broker, NPresamples, NSamples)
 
 	//kink model parameters
 	var a, b, c float64
@@ -648,7 +656,9 @@ func TestEdgeVetosLevel(t *testing.T) {
 	broker := NewTriggerBroker(nchan)
 	go broker.Run()
 	defer broker.Stop()
-	dsp := NewDataStreamProcessor(0, broker)
+	NPresamples := 256
+	NSamples := 1024
+	dsp := NewDataStreamProcessor(0, broker, NPresamples, NSamples)
 	dsp.NPresamples = 20
 	dsp.NSamples = 100
 
@@ -688,7 +698,9 @@ func BenchmarkAutoTriggerOpsAre100SampleTriggers(b *testing.B) {
 	broker := NewTriggerBroker(nchan)
 	go broker.Run()
 	defer broker.Stop()
-	dsp := NewDataStreamProcessor(0, broker)
+	NPresamples := 256
+	NSamples := 1024
+	dsp := NewDataStreamProcessor(0, broker, NPresamples, NSamples)
 	dsp.NPresamples = 20
 	dsp.NSamples = 100
 	dsp.AutoTrigger = true
@@ -712,7 +724,9 @@ func BenchmarkEdgeTrigger0TriggersOpsAreSamples(b *testing.B) {
 	broker := NewTriggerBroker(nchan)
 	go broker.Run()
 	defer broker.Stop()
-	dsp := NewDataStreamProcessor(0, broker)
+	NPresamples := 256
+	NSamples := 1024
+	dsp := NewDataStreamProcessor(0, broker, NPresamples, NSamples)
 	dsp.NPresamples = 20
 	dsp.NSamples = 100
 
@@ -745,7 +759,9 @@ func BenchmarkLevelTrigger0TriggersOpsAreSamples(b *testing.B) {
 	broker := NewTriggerBroker(nchan)
 	go broker.Run()
 	defer broker.Stop()
-	dsp := NewDataStreamProcessor(0, broker)
+	NPresamples := 256
+	NSamples := 1024
+	dsp := NewDataStreamProcessor(0, broker, NPresamples, NSamples)
 	dsp.NPresamples = 20
 	dsp.NSamples = 100
 


### PR DESCRIPTION
This PR passes `NPresamples` and `NSamples` as arguments to `Start`, `PrepareRun`, and `NewDatastreamProcessor`. This allows the record lengths to be correct when starting a source. This removes the previous approach of calling `ConfigureRecordLengths` after `Start`. I believe the new approach is less error prone, as you can't forget to set the record lengths.

There is also a new function `getPulseLengths` used to test that this actually works. So hopefully we won't run into this problem.

The PR is kind of long because I had to fix lots of tests to use the new APIs.

~~It also makes setting the same record lengths as before an error (I'm not sure if this is a great idea, but I dont like silently ignoring user input).~~

fixes #116 