### PR TITLE
fix timestamp on rpc command receipt for SetExperimentStateLabel

### DIFF
--- a/rpc_server.go
+++ b/rpc_server.go
@@ -372,9 +372,11 @@ type StateLabelConfig struct {
 }
 
 // SetExperimentStateLabel sets the experiment state label in the _experiment_state file
+// The timestamp is fixed as soon as the RPC command is recieved
 func (s *SourceControl) SetExperimentStateLabel(config *StateLabelConfig, reply *bool) error {
+	timestamp := time.Now()
 	f := func() {
-		s.queuedResults <- s.ActiveSource.SetExperimentStateLabel(config.Label)
+		s.queuedResults <- s.ActiveSource.SetExperimentStateLabel(timestamp, config.Label)
 	}
 	err := s.runLaterIfActive(f)
 	*reply = (err == nil)


### PR DESCRIPTION
The RPC command `SetExperimentStateLabel` is changed to grab a timestamp as soon as the RPC command is received, instead of when the delayed closure is executed. I think this will be more useful experimentally.