### PR TITLE
simulated pulse sources have rows and cols

### DIFF
--- a/ljh/ljh.go
+++ b/ljh/ljh.go
@@ -151,17 +151,14 @@ func (w *Writer) WriteHeader(firstRecord time.Time) error {
 	timestamp := float64(w.TimestampOffset.UnixNano()) / 1e9
 	firstrec := firstRecord.Format("02 Jan 2006, 15:04:05 MST")
 
-	rowColText := "Number of rows: 0\nNumber of columns: 0"
-	if w.SourceName == "Lancero" {
-		rowColText = fmt.Sprintf(`Number of rows: %d
+	rowColText := fmt.Sprintf(`Number of rows: %d
 Number of columns: %d
 Row number (from 0-%d inclusive): %d
 Column number (from 0-%d inclusive): %d`,
-			w.NumberOfRows, w.NumberOfColumns,
-			w.NumberOfRows-1, w.RowNum,
-			w.NumberOfColumns-1, w.ColumnNum,
-		)
-	}
+		w.NumberOfRows, w.NumberOfColumns,
+		w.NumberOfRows-1, w.RowNum,
+		w.NumberOfColumns-1, w.ColumnNum,
+	)
 	s := fmt.Sprintf(`#LJH Memorial File Format
 Save File Format Version: 2.2.1
 Software Version: DASTARD version %s

--- a/simulated_data_sources.go
+++ b/simulated_data_sources.go
@@ -85,6 +85,7 @@ func (ts *TriangleSource) Sample() error {
 	for i := 0; i < ts.nchan; i++ {
 		ts.chanNames[i] = fmt.Sprintf("chan%d", i+1)
 		ts.chanNumbers[i] = i + 1
+		ts.rowColCodes[i] = rcCode(0, i, 1, ts.nchan)
 	}
 	return nil
 }
@@ -213,6 +214,7 @@ func (sps *SimPulseSource) Sample() error {
 	for i := 0; i < sps.nchan; i++ {
 		sps.chanNames[i] = fmt.Sprintf("chan%d", i+1)
 		sps.chanNumbers[i] = i + 1
+		sps.rowColCodes[i] = rcCode(0, i, 1, sps.nchan)
 	}
 	return nil
 }

--- a/simulated_data_test.go
+++ b/simulated_data_test.go
@@ -30,6 +30,12 @@ func TestTriangle(t *testing.T) {
 	if len(ts.processors) != config.Nchan {
 		t.Errorf("TriangleSource.Ouputs() returns %d channels, want %d", len(ts.processors), config.Nchan)
 	}
+	if ts.rowColCodes[0].rows() != 1 {
+		fmt.Errorf("have %v, expect 1", ts.rowColCodes[0].rows())
+	}
+	if ts.rowColCodes[3].rows() != 1 {
+		fmt.Errorf("have %v, expect 1", ts.rowColCodes[3].rows())
+	}
 
 	// Check first segment per source.
 	// n := int(config.Max - config.Min)


### PR DESCRIPTION
I made it so simulated pulse sources have rows and columns. This makes mass play nicer with opening files written from them. I chose to make each channel a column, so there are `nchan` columns and 1 row in all cases. That because there is not timing relationship between rows like in lancero source.

Fixes #120 

I already merged it to Jamie's branch, so no rush on merging it to master.