### PR TITLE
External trigger

### DIFF
--- a/data_source.go
+++ b/data_source.go
@@ -517,6 +517,9 @@ func (ds *AnySource) WriteControl(config *WriteControlConfig) error {
 		ds.writingState.ExperimentStateLabel = ""
 		ds.writingState.ExperimentStateLabelUnixNano = 0
 		if ds.writingState.externalTriggerFile != nil {
+			if err := ds.writingState.externalTriggerFileBufferedWriter.Flush(); err != nil {
+				return fmt.Errorf("failed to flush externalTriggerFileBufferedWriter, err: %v", err)
+			}
 			if err := ds.writingState.externalTriggerFile.Close(); err != nil {
 				return fmt.Errorf("failed to close externalTriggerFileWriter, err: %v", err)
 			}

--- a/lancero_source.go
+++ b/lancero_source.go
@@ -31,11 +31,10 @@ type LanceroDevice struct {
 // BuffersChanType is an internal message type used to allow
 // a goroutine to read from the Lancero card and put data on a buffered channel
 type BuffersChanType struct {
-	datacopies               [][]RawType
-	externalTriggerRowcounts []int64
-	lastSampleTime           time.Time
-	timeDiff                 time.Duration
-	totalBytes               int
+	datacopies     [][]RawType
+	lastSampleTime time.Time
+	timeDiff       time.Duration
+	totalBytes     int
 }
 
 // LanceroSource is a DataSource that handles 1 or more lancero devices.


### PR DESCRIPTION
Closes #122. This scans for external trigger bits, and records rowcounts of each level trigger. The data is written to a file with name like "ABC_external_trigger.bin" with a single line header followed by binary data. The file is flushed once/second. It also adds a new message type "EXTERNALTRIGGER" that reports the number of triggers observed in the last second. 

I've tested it on the Horton crate with 8 cols X 8 rows at 100MB/s (lsync 40). I've observed
- Correct rate reporting up to about 6kHz, limited by the function generator I was using. 
- Succesfully starting and stoping and restarting file writing many times.
- external_trigger file has roughly correct contents (didn't check carefully)
- 40% cpu usage while writing to file with 5kHz external triggers, and no other triggers

I'd love to have tests for this, but they seem hard to write.