### PR TITLE
minimal fix for #131, make sure LanceroSource.AvailableCards is populated

### DIFF
--- a/lancero_source.go
+++ b/lancero_source.go
@@ -125,6 +125,14 @@ type LanceroSourceConfig struct {
 func (ls *LanceroSource) Configure(config *LanceroSourceConfig) (err error) {
 	ls.sourceStateLock.Lock()
 	defer ls.sourceStateLock.Unlock()
+
+	// populate AvailableCards before any possible errors
+	config.AvailableCards = make([]int, 0)
+	for k := range ls.devices {
+		config.AvailableCards = append(config.AvailableCards, k)
+	}
+	sort.Ints(config.AvailableCards)
+
 	if ls.sourceState != Inactive {
 		return fmt.Errorf("cannot Configure a LanceroSource if it's not Inactive")
 	}
@@ -154,11 +162,6 @@ func (ls *LanceroSource) Configure(config *LanceroSourceConfig) (err error) {
 		dev.fiberMask = config.FiberMask
 		dev.clockMhz = config.ClockMhz
 	}
-	config.AvailableCards = make([]int, 0)
-	for k := range ls.devices {
-		config.AvailableCards = append(config.AvailableCards, k)
-	}
-	sort.Ints(config.AvailableCards)
 
 	ls.nsamp = config.Nsamp
 	return err

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -541,6 +541,9 @@ func RunRPCServer(portrpc int, block bool) {
 	var spc SimPulseSourceConfig
 	log.Printf("Dastard is using config file %s\n", viper.ConfigFileUsed())
 	err := viper.UnmarshalKey("simpulse", &spc)
+	if spc.Nchan == 0 { // default to a valid Nchan value to avoid ConfigureSimPulseSource throwing an error
+		spc.Nchan = 1
+	}
 	if err == nil {
 		err0 := sourceControl.ConfigureSimPulseSource(&spc, &okay)
 		if err0 != nil {

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -542,17 +542,29 @@ func RunRPCServer(portrpc int, block bool) {
 	log.Printf("Dastard is using config file %s\n", viper.ConfigFileUsed())
 	err := viper.UnmarshalKey("simpulse", &spc)
 	if err == nil {
-		sourceControl.ConfigureSimPulseSource(&spc, &okay)
+		err0 := sourceControl.ConfigureSimPulseSource(&spc, &okay)
+		if err0 != nil {
+			panic(err0)
+		}
 	}
 	var tsc TriangleSourceConfig
 	err = viper.UnmarshalKey("triangle", &tsc)
 	if err == nil {
-		sourceControl.ConfigureTriangleSource(&tsc, &okay)
+		err0 := sourceControl.ConfigureTriangleSource(&tsc, &okay)
+		if err0 != nil {
+			panic(err0)
+		}
 	}
 	var lsc LanceroSourceConfig
 	err = viper.UnmarshalKey("lancero", &lsc)
+	if lsc.Nsamp == 0 { // default to a valid Nsamp value to avoid ConfigureLanceroSource throwing an error
+		lsc.Nsamp = 16
+	}
 	if err == nil {
-		sourceControl.ConfigureLanceroSource(&lsc, &okay)
+		err0 := sourceControl.ConfigureLanceroSource(&lsc, &okay)
+		if err0 != nil {
+			panic(err0)
+		}
 	}
 	err = viper.UnmarshalKey("status", &sourceControl.status)
 	sourceControl.status.Running = false

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -552,6 +552,9 @@ func RunRPCServer(portrpc int, block bool) {
 	}
 	var tsc TriangleSourceConfig
 	err = viper.UnmarshalKey("triangle", &tsc)
+	if tsc.Nchan == 0 { // default to a valid Nchan value to avoid ConfigureTriangleSource throwing an error
+		tsc.Nchan = 1
+	}
 	if err == nil {
 		err0 := sourceControl.ConfigureTriangleSource(&tsc, &okay)
 		if err0 != nil {


### PR DESCRIPTION
Here I make `Nsamp=16` the default, rather than `Nsamp=0`. This is because `16` is an unlikely value, so people will notice it, and it doesn't cause `Configure` to throw an error like `Nsamp=0` does. Also I made each call to `Configure` for the various sources panic if it returns an error, so we can more easily debug problems here. I also move the calls to populate `ls.AvailableCards` before any errors, this change is unnecessary but would also fix #131 on it's own so it seem reasonable to include.