### PR TITLE
Read lsync, nrows, nsamp, clockMHz from cringeGlobals.json

### DIFF
--- a/lancero/test_data/cringeGlobals.json
+++ b/lancero/test_data/cringeGlobals.json
@@ -1,0 +1,10 @@
+{
+    "SETT": 18, 
+    "seqln": 28, 
+    "lsync": 30, 
+    "testpattern": 2, 
+    "propagationdelay": 9, 
+    "NSAMP": 10, 
+    "carddelay": 7,
+    "XPT": 3
+}

--- a/lancero_source.go
+++ b/lancero_source.go
@@ -114,8 +114,15 @@ type LanceroSourceConfig struct {
 	FiberMask         uint32
 	CardDelay         []int
 	ActiveCards       []int
-	AvailableCards    []int
 	ShouldAutoRestart bool
+	DastardOutput     LanceroDastardOutputJSON
+}
+
+// LanceroDastardOutputJSON is used to return values over the JSON RPC which cannot be set over the JSON rpc
+type LanceroDastardOutputJSON struct {
+	Nsamp          int
+	ClockMHz       int
+	AvailableCards []int
 }
 
 // Configure sets up the internal buffers with given size, speed, and min/max.
@@ -129,11 +136,11 @@ func (ls *LanceroSource) Configure(config *LanceroSourceConfig) (err error) {
 	defer ls.sourceStateLock.Unlock()
 
 	// populate AvailableCards before any possible errors
-	config.AvailableCards = make([]int, 0)
+	config.DastardOutput.AvailableCards = make([]int, 0)
 	for k := range ls.devices {
-		config.AvailableCards = append(config.AvailableCards, k)
+		config.DastardOutput.AvailableCards = append(config.DastardOutput.AvailableCards, k)
 	}
-	sort.Ints(config.AvailableCards)
+	sort.Ints(config.DastardOutput.AvailableCards)
 
 	var cg cringeGlobals
 	cg, err = cringeGlobalsRead(cringeGlobalsPath)
@@ -176,6 +183,9 @@ func (ls *LanceroSource) Configure(config *LanceroSourceConfig) (err error) {
 	}
 
 	ls.nsamp = cg.Nsamp
+	config.DastardOutput.Nsamp = cg.Nsamp
+	config.DastardOutput.ClockMHz = cg.ClockMHz
+
 	return err
 }
 

--- a/lancero_source.go
+++ b/lancero_source.go
@@ -388,7 +388,7 @@ func roundint(x float64) int {
 }
 
 type cringeGlobals struct {
-	Sett             int `json:"SETT"`
+	Settle           int `json:"SETT"`
 	SequenceLength   int `json:"seqln"`
 	Lsync            int `json:"lsync"`
 	TestPattern      int `json:"testpattern"`

--- a/lancero_test.go
+++ b/lancero_test.go
@@ -112,8 +112,8 @@ func TestNoHardwareSource(t *testing.T) {
 		t.Error(err)
 	}
 	for i := 0; i < nLancero; i++ {
-		if config.ActiveCards[i] != config.AvailableCards[i] {
-			t.Errorf("AvailableCards not populated correctly. AvailableCards %v", config.AvailableCards)
+		if config.ActiveCards[i] != config.DastardOutput.AvailableCards[i] {
+			t.Errorf("AvailableCards not populated correctly. AvailableCards %v", config.DastardOutput.AvailableCards)
 		}
 	}
 

--- a/lancero_test.go
+++ b/lancero_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/usnistgov/dastard/lancero"
 )
 
@@ -91,6 +92,12 @@ func TestNoHardwareSource(t *testing.T) {
 		source.ncards++
 	}
 	// above is essentially NewLanceroSource
+	cg, err7 := source.ReadCringeGlobals("lancero/test_data/cringeGlobals.json")
+	if err7 != nil {
+		t.Error(err7)
+	}
+	spew.Dump(cg)
+	source.InjestCringeGlobals(cg)
 
 	config := LanceroSourceConfig{ClockMhz: 125, CardDelay: cardDelay,
 		ActiveCards: make([]int, nLancero)}

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -563,9 +563,6 @@ func RunRPCServer(portrpc int, block bool) {
 	}
 	var lsc LanceroSourceConfig
 	err = viper.UnmarshalKey("lancero", &lsc)
-	if lsc.Nsamp == 0 { // default to a valid Nsamp value to avoid ConfigureLanceroSource throwing an error
-		lsc.Nsamp = 16
-	}
 	if err == nil {
 		err0 := sourceControl.ConfigureLanceroSource(&lsc, &okay)
 		if err0 != nil {

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -668,9 +668,7 @@ func RunRPCServer(portrpc int, block bool) {
 					for {
 						err := server.ServeRequest(codec)
 						if err != nil {
-							log.Printf("server error: %v", err)
-							log.Printf("codec:")
-							spew.Dump(codec)
+							//spew.Dump(codec)
 							break
 						}
 					}

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -668,7 +668,9 @@ func RunRPCServer(portrpc int, block bool) {
 					for {
 						err := server.ServeRequest(codec)
 						if err != nil {
-							log.Printf("server stopped: %v", err)
+							log.Printf("server error: %v", err)
+							log.Printf("codec:")
+							spew.Dump(codec)
 							break
 						}
 					}

--- a/rpc_server_test.go
+++ b/rpc_server_test.go
@@ -429,6 +429,9 @@ func TestMain(m *testing.M) {
 	log.SetOutput(f)
 	lancero.SetLogOutput(f)
 
+	// set global cringeGlobalsPath to point to test file
+	cringeGlobalsPath = "lancero/test_data/cringeGlobals.json"
+
 	// Find config file, creating it if needed, and read it.
 	if err := setupViper(); err != nil {
 		panic(err)


### PR DESCRIPTION
This changes `LanceroSource.Configure` to read from `~/.cringe/cringeGlobals.json` to learn `lsync`, `nrows`, `Nsamp`, and `clockMHz`. In `sampleCard` where we calculate `nrows` and `lsync` there is now an error if `nrows` doesn't match, and a warning if `lsync` doesn't match. 

Tests that used `LanceroSource.Configure` to set these values now have to reach inside of `LanceroSource` to set these values directly, so they are a bit uglier. Also for testing, it reads from `lancero/test_data/cringeGlobals.json` since `~/.cringe/cringeGlobals.json` won't exist on travis or my laptop.

I think this will work without any modifications to dastard commander, since Dastard will just ignore extraneous values in the json that gets sent over the RPC. So it should be easy to test. But we should make dastard commander aware of these changes before merging.