### PR TITLE
Failure to ConfigureLanceroSource does not cause a panic

### DIFF
--- a/data_source.go
+++ b/data_source.go
@@ -254,6 +254,7 @@ type AnySource struct {
 	abortSelf    chan struct{}   // Signal to the core loop of active sources to stop
 	nextBlock    chan *dataBlock // Signal from the core loop that a block is ready to process
 	broker       *TriggerBroker
+	configError  error // Any error that arose when configuring the source (before Start)
 
 	shouldAutoRestart   bool // used to tell SourceControl to try to restart this source after an error
 	noProcess           bool // Set true only for testing.

--- a/data_source.go
+++ b/data_source.go
@@ -42,6 +42,7 @@ type DataSource interface {
 	Running() bool
 	GetState() SourceState
 	SetStateStarting() error
+	SetStateInactive() error
 	getNextBlock() chan *dataBlock
 	Nchan() int
 	VoltsPerArb() []float32
@@ -115,10 +116,12 @@ func Start(ds DataSource, queuedRequests chan func(), Npresamp int, Nsamples int
 	}
 
 	if err := ds.Sample(); err != nil {
+		ds.SetStateInactive()
 		return err
 	}
 
 	if err := ds.PrepareRun(Npresamp, Nsamples); err != nil {
+		ds.SetStateInactive()
 		return err
 	}
 
@@ -644,6 +647,14 @@ func (ds *AnySource) SetStateStarting() error {
 		return nil
 	}
 	return fmt.Errorf("cannot Start() a source that's %v, not Inactive", ds.sourceState)
+}
+
+// SetStateInactive sets the sourceState value to Inactive in a race-free fashion
+func (ds *AnySource) SetStateInactive() error {
+	ds.sourceStateLock.Lock()
+	defer ds.sourceStateLock.Unlock()
+	ds.sourceState = Inactive
+	return nil
 }
 
 // VoltsPerArb returns a per-channel value scaling raw into volts.

--- a/lancero_source.go
+++ b/lancero_source.go
@@ -236,6 +236,10 @@ func (ls *LanceroSource) ConfigureMixFraction(mfo *MixFractionObject) ([]float64
 
 // Sample determines key data facts by sampling some initial data.
 func (ls *LanceroSource) Sample() error {
+	// Cannot start this process if configuration failed.
+	if ls.configError != nil {
+		return ls.configError
+	}
 	ls.dataBlockCount = 0
 	ls.nchan = 0
 	for _, device := range ls.active {

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -126,6 +126,8 @@ func (s *SourceControl) ConfigureSimPulseSource(args *SimPulseSourceConfig, repl
 func (s *SourceControl) ConfigureLanceroSource(args *LanceroSourceConfig, reply *bool) error {
 	log.Printf("ConfigureLanceroSource: mask 0x%4.4x  active cards: %v\n", args.FiberMask, args.ActiveCards)
 	err := s.lancero.Configure(args)
+	// Remember any errors for later, when we try to start the source.
+	s.lancero.configError = err
 	s.clientUpdates <- ClientUpdate{"LANCERO", args}
 	*reply = (err == nil)
 	log.Printf("Result is okay=%t and state={%d MHz clock, %d cards}\n", *reply, s.lancero.clockMhz, s.lancero.ncards)
@@ -595,10 +597,8 @@ func RunRPCServer(portrpc int, block bool) {
 	var lsc LanceroSourceConfig
 	err = viper.UnmarshalKey("lancero", &lsc)
 	if err == nil {
-		err0 := sourceControl.ConfigureLanceroSource(&lsc, &okay)
-		if err0 != nil {
-			panic(err0)
-		}
+		sourceControl.ConfigureLanceroSource(&lsc, &okay)
+		// Don't panic on config errors: they are expected on a system w/o Lancero cards!
 	}
 	var asc AbacoSourceConfig
 	err = viper.UnmarshalKey("abaco", &asc)

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -585,7 +585,8 @@ func RunRPCServer(portrpc int, block bool) {
 	}
 	var tsc TriangleSourceConfig
 	err = viper.UnmarshalKey("triangle", &tsc)
-	if tsc.Nchan == 0 { // default to a valid Nchan value to avoid ConfigureTriangleSource throwing an error
+	// Default to a valid Nchan value to avoid ConfigureTriangleSource throwing an error
+	if tsc.Nchan == 0 {
 		tsc.Nchan = 1
 	}
 	if err == nil {
@@ -597,8 +598,9 @@ func RunRPCServer(portrpc int, block bool) {
 	var lsc LanceroSourceConfig
 	err = viper.UnmarshalKey("lancero", &lsc)
 	if err == nil {
-		sourceControl.ConfigureLanceroSource(&lsc, &okay)
-		// Don't panic on config errors: they are expected on a system w/o Lancero cards!
+		_ = sourceControl.ConfigureLanceroSource(&lsc, &okay)
+		// Don't panic on config errors: they are expected on any system w/o Lancero cards.
+		// That is, we are intentionally NOT checking any error returned by ConfigureLanceroSource.
 	}
 	var asc AbacoSourceConfig
 	err = viper.UnmarshalKey("abaco", &asc)


### PR DESCRIPTION
If `ConfigureLanceroSource` fails (e.g., because there's no cringe configuration file), then remember this error but don't panic. For a non-Lancero computer, this failure is normal behavior.

Instead of panicking, remember the error and refuse to start the source in the `Sample()` method. (Given that a non-Lancero machine won't have `/dev/lancero_user*` files, this will not actually come up in practice.)

Fixes #140.