### PR TITLE
write projectors and basis as binary after JSON header in off files

### DIFF
--- a/off/off_test.go
+++ b/off/off_test.go
@@ -49,7 +49,7 @@ func TestOff(t *testing.T) {
 	w.Flush()
 	stat, _ := os.Stat("off_test.off")
 	sizeHeader := stat.Size()
-	if err := w.WriteRecord(0, 0, 0, 0, 0, 0, make([]float32, 3)); err != nil {
+	if err := w.WriteRecord(0, 0, 123456, 0, 0, .123456, make([]float32, 3)); err != nil {
 		t.Error(err)
 	}
 	w.Flush()


### PR DESCRIPTION
fixes #128 

the `fixes_for_ebit` branch of mass has corresponding changes to reading off files
this should speed up parsing off files, and make the headers much more human readable since there will no longer be a giant wall of random text taking up most of the header