### PR TITLE
position info to file headers

### DIFF
--- a/data_source.go
+++ b/data_source.go
@@ -502,6 +502,15 @@ func (ds *AnySource) writeControlStart(config *WriteControlConfig) error {
 		rowNum := rccode.row()
 		colNum := rccode.col()
 		fps := 1
+		var pixel Pixel
+		if config.m != nil && len(config.m.Pixels) >= i {
+			pixel = config.m.Pixels[i]
+		} else {
+			const MaxUint = ^uint(0)
+			const MaxInt = int(MaxUint >> 1)
+			const MinInt = -MaxInt - 1 // cauclate MinInt following https://stackoverflow.com/questions/6878590/the-maximum-value-for-an-int-type-in-go
+			pixel = Pixel{Name: "no map information", X: MinInt, Y: MinInt}
+		}
 		if dsp.Decimate {
 			fps = dsp.DecimateLevel
 		}
@@ -509,14 +518,14 @@ func (ds *AnySource) writeControlStart(config *WriteControlConfig) error {
 			filename := fmt.Sprintf(filenamePattern, dsp.Name, "ljh")
 			dsp.DataPublisher.SetLJH22(i, dsp.NPresamples, dsp.NSamples, fps,
 				timebase, Build.RunStart, nrows, ncols, ds.nchan, rowNum, colNum, filename,
-				ds.name, ds.chanNames[i], ds.chanNumbers[i])
+				ds.name, ds.chanNames[i], ds.chanNumbers[i], pixel)
 		}
 		if config.WriteOFF && dsp.HasProjectors() {
 			filename := fmt.Sprintf(filenamePattern, dsp.Name, "off")
 			dsp.DataPublisher.SetOFF(i, dsp.NPresamples, dsp.NSamples, fps,
 				timebase, Build.RunStart, nrows, ncols, ds.nchan, rowNum, colNum, filename,
 				ds.name, ds.chanNames[i], ds.chanNumbers[i], dsp.projectors, dsp.basis,
-				dsp.modelDescription)
+				dsp.modelDescription, pixel)
 			channelsWithOff++
 		}
 		if config.WriteLJH3 {

--- a/ljh/ljh.go
+++ b/ljh/ljh.go
@@ -69,6 +69,9 @@ type Writer struct {
 	ChannelNumberMatchingName int
 	ColumnNum                 int
 	RowNum                    int
+	PixelXPosition            int
+	PixelYPosition            int
+	PixelName                 string
 
 	file   *os.File
 	writer *bufio.Writer
@@ -176,11 +179,14 @@ Number of samples per point: %d
 Timestamp offset (s): %.6f
 Server Start Time: %s
 First Record Time: %s
+Pixel X Position: %d
+Pixel Y Position: %d
+Pixel Name: %s
 Timebase: %e
 #End of Header
 `, w.DastardVersion, w.GitHash, w.SourceName, rowColText, w.NumberOfChans,
 		w.ChanName, w.ChannelNumberMatchingName, w.ChannelIndex, w.Presamples, w.Samples, w.FramesPerSample,
-		timestamp, starttime, firstrec, w.Timebase,
+		timestamp, starttime, firstrec, w.PixelXPosition, w.PixelYPosition, w.PixelName, w.Timebase,
 	)
 	_, err := w.writer.WriteString(s)
 	w.HeaderWritten = true

--- a/off/off.go
+++ b/off/off.go
@@ -39,6 +39,7 @@ type Writer struct {
 	ModelInfo                 ModelInfo
 	CreationInfo              CreationInfo
 	ReadoutInfo               TimeDivisionMultiplexingInfo
+	PixelInfo                 PixelInfo
 
 	// items not serialized to JSON header
 	recordsWritten int
@@ -53,7 +54,7 @@ func NewWriter(fileName string, ChannelIndex int, ChannelName string, ChannelNum
 	MaxPresamples int, MaxSamples int, FramePeriodSeconds float64,
 	Projectors *mat.Dense, Basis *mat.Dense, ModelDescription string,
 	DastardVersion string, GitHash string, SourceName string,
-	ReadoutInfo TimeDivisionMultiplexingInfo) *Writer {
+	ReadoutInfo TimeDivisionMultiplexingInfo, pixelInfo PixelInfo) *Writer {
 	writer := new(Writer)
 	writer.ChannelIndex = ChannelIndex
 	writer.ChannelName = ChannelName
@@ -68,6 +69,7 @@ func NewWriter(fileName string, ChannelIndex int, ChannelName string, ChannelNum
 	writer.CreationInfo = CreationInfo{DastardVersion: DastardVersion, GitHash: GitHash,
 		SourceName: SourceName, CreationTime: time.Now()}
 	writer.ReadoutInfo = ReadoutInfo
+	writer.PixelInfo = pixelInfo
 	writer.fileName = fileName
 	return writer
 }
@@ -79,6 +81,12 @@ type ModelInfo struct {
 	Basis       ArrayJsoner
 	basis       *mat.Dense
 	Description string
+}
+
+type PixelInfo struct {
+	XPosition int
+	YPosition int
+	Name      string
 }
 
 // ArrayJsoner aids in formatting arrays for writing to JSON

--- a/off/off_test.go
+++ b/off/off_test.go
@@ -30,7 +30,8 @@ func TestOff(t *testing.T) {
 			0, 0, 0})
 
 	w := NewWriter("off_test.off", 0, "chan1", 1, 100, 200, 9.6e-6, projectors, basis, "dummy model for testing",
-		"DastardVersion Placeholder", "GitHash Placeholder", "SourceName Placeholder", TimeDivisionMultiplexingInfo{})
+		"DastardVersion Placeholder", "GitHash Placeholder", "SourceName Placeholder", TimeDivisionMultiplexingInfo{},
+		PixelInfo{})
 	if err := w.CreateFile(); err != nil {
 		t.Fatal(err)
 	}

--- a/publish_data.go
+++ b/publish_data.go
@@ -51,13 +51,14 @@ func (dp *DataPublisher) SetOFF(ChannelIndex int, Presamples int, Samples int, F
 	Timebase float64, TimestampOffset time.Time,
 	NumberOfRows, NumberOfColumns, NumberOfChans, rowNum, colNum int,
 	FileName, sourceName, chanName string, ChannelNumberMatchingName int,
-	Projectors *mat.Dense, Basis *mat.Dense, ModelDescription string) {
+	Projectors *mat.Dense, Basis *mat.Dense, ModelDescription string, pixel Pixel) {
 	ReadoutInfo := off.TimeDivisionMultiplexingInfo{NumberOfRows: NumberOfRows,
 		NumberOfColumns: NumberOfColumns,
 		NumberOfChans:   NumberOfChans,
 		ColumnNum:       colNum, RowNum: rowNum}
+	PixelInfo := off.PixelInfo{XPosition: pixel.X, YPosition: pixel.Y, Name: pixel.Name}
 	w := off.NewWriter(FileName, ChannelIndex, chanName, ChannelNumberMatchingName, Presamples, Samples, Timebase,
-		Projectors, Basis, ModelDescription, Build.Version, Build.Githash, sourceName, ReadoutInfo)
+		Projectors, Basis, ModelDescription, Build.Version, Build.Githash, sourceName, ReadoutInfo, PixelInfo)
 	dp.OFF = w
 	dp.numberWritten = 0
 }
@@ -108,7 +109,7 @@ func (dp *DataPublisher) RemoveLJH3() {
 func (dp *DataPublisher) SetLJH22(ChannelIndex int, Presamples int, Samples int, FramesPerSample int,
 	Timebase float64, TimestampOffset time.Time,
 	NumberOfRows, NumberOfColumns, NumberOfChans, rowNum, colNum int,
-	FileName, sourceName, chanName string, ChannelNumberMatchingName int) {
+	FileName, sourceName, chanName string, ChannelNumberMatchingName int, pixel Pixel) {
 	w := ljh.Writer{ChannelIndex: ChannelIndex,
 		Presamples:                Presamples,
 		Samples:                   Samples,
@@ -126,6 +127,9 @@ func (dp *DataPublisher) SetLJH22(ChannelIndex int, Presamples int, Samples int,
 		SourceName:                sourceName,
 		ColumnNum:                 colNum,
 		RowNum:                    rowNum,
+		PixelXPosition:            pixel.X,
+		PixelYPosition:            pixel.Y,
+		PixelName:                 pixel.Name,
 	}
 	dp.LJH22 = &w
 	dp.WritingPaused = false

--- a/publish_data_test.go
+++ b/publish_data_test.go
@@ -22,7 +22,7 @@ func TestPublishData(t *testing.T) {
 	}
 	startTime := time.Now()
 	dp.SetLJH22(1, 4, len(d), 1, 1, startTime, 8, 1, 16, 3, 0,
-		"TestPublishData.ljh", "testSource", "chanX", 1)
+		"TestPublishData.ljh", "testSource", "chanX", 1, Pixel{})
 	if err := dp.PublishData(records); err != nil {
 		t.Fail()
 	}
@@ -103,7 +103,7 @@ func TestPublishData(t *testing.T) {
 	projectors := mat.NewDense(nbases, nsamples, make([]float64, nbases*nsamples))
 	basis := mat.NewDense(nsamples, nbases, make([]float64, nbases*nsamples))
 	dp.SetOFF(0, 0, 0, 1, 1, time.Now(), 1, 1, 1, 1, 1, "TestPublishData.off", "sourceName",
-		"chanName", 1, projectors, basis, "ModelDescription")
+		"chanName", 1, projectors, basis, "ModelDescription", Pixel{})
 	if err := dp.PublishData(records); err != nil {
 		t.Error(err)
 	}
@@ -210,7 +210,7 @@ func BenchmarkPublish(b *testing.B) {
 	b.Run("PubLJH22", func(b *testing.B) {
 		dp := DataPublisher{}
 		dp.SetLJH22(0, 0, len(d), 1, 0, startTime, 0, 0, 0, 0, 0,
-			"TestPublishData.ljh", "testSource", "chanX", 1)
+			"TestPublishData.ljh", "testSource", "chanX", 1, Pixel{})
 		defer dp.RemoveLJH22()
 		slowPart(b, dp, records)
 	})
@@ -227,7 +227,7 @@ func BenchmarkPublish(b *testing.B) {
 		dp.SetPubSummaries()
 		defer dp.RemovePubSummaries()
 		dp.SetLJH22(0, 0, len(d), 1, 0, startTime, 0, 0, 0, 0, 0,
-			"TestPublishData.ljh", "testSource", "chanX", 1)
+			"TestPublishData.ljh", "testSource", "chanX", 1, Pixel{})
 		defer dp.RemoveLJH22()
 		dp.SetLJH3(0, 0, 0, 0, "TestPublishData.ljh3")
 		defer dp.RemoveLJH3()

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -32,6 +32,7 @@ type SourceControl struct {
 	erroring       *ErroringSource
 	ActiveSource   DataSource
 	isSourceActive bool
+	mapServer      *MapServer
 
 	status        ServerStatus
 	clientUpdates chan<- ClientUpdate
@@ -383,10 +384,12 @@ type WriteControlConfig struct {
 	WriteLJH22 bool   // turn on one or more file formats
 	WriteOFF   bool
 	WriteLJH3  bool
+	m          *Map // for dastard internal use only, used to pass map info to DataStreamProcessors
 }
 
 // WriteControl requests start/stop/pause/unpause data writing
 func (s *SourceControl) WriteControl(config *WriteControlConfig, reply *bool) error {
+	config.m = s.mapServer.m
 	f := func() {
 		err := s.ActiveSource.WriteControl(config)
 		if err == nil {
@@ -618,6 +621,7 @@ func RunRPCServer(portrpc int, block bool) {
 	sourceControl.status.Running = false
 	sourceControl.ActiveSource = sourceControl.triangle
 	sourceControl.isSourceActive = false
+	sourceControl.mapServer = mapServer
 	if err == nil {
 		sourceControl.broadcastStatus()
 	}


### PR DESCRIPTION
Pass position info to `LJH22` and `off` file headers. Having `MapServer` separate from `SourceControl` source control doesn't seem helpful, as I have to keep a reference to `MapServer` to be able to know anything about pixels. I didn't change it because I didn't want to change the tests, but I think we should just accept that `SourceControl` is a god object.

fixes #108 