### PR TITLE
Small fixes2

### DIFF
--- a/client_updater.go
+++ b/client_updater.go
@@ -1,7 +1,8 @@
 package dastard
 
 // Contain the ClientUpdater object, which publishes JSON-encoded messages
-// giving the latest DASTARD state.
+// giving the latest DASTARD state. Most of these messages are saved to
+// disk with viper.
 
 import (
 	"encoding/json"

--- a/data_source.go
+++ b/data_source.go
@@ -517,13 +517,13 @@ func (ds *AnySource) writeControlStart(config *WriteControlConfig) error {
 		if config.WriteLJH22 {
 			filename := fmt.Sprintf(filenamePattern, dsp.Name, "ljh")
 			dsp.DataPublisher.SetLJH22(i, dsp.NPresamples, dsp.NSamples, fps,
-				timebase, Build.RunStart, nrows, ncols, ds.nchan, rowNum, colNum, filename,
+				timebase, DastardStartTime, nrows, ncols, ds.nchan, rowNum, colNum, filename,
 				ds.name, ds.chanNames[i], ds.chanNumbers[i], pixel)
 		}
 		if config.WriteOFF && dsp.HasProjectors() {
 			filename := fmt.Sprintf(filenamePattern, dsp.Name, "off")
 			dsp.DataPublisher.SetOFF(i, dsp.NPresamples, dsp.NSamples, fps,
-				timebase, Build.RunStart, nrows, ncols, ds.nchan, rowNum, colNum, filename,
+				timebase, DastardStartTime, nrows, ncols, ds.nchan, rowNum, colNum, filename,
 				ds.name, ds.chanNames[i], ds.chanNumbers[i], dsp.projectors, dsp.basis,
 				dsp.modelDescription, pixel)
 			channelsWithOff++

--- a/global_config.go
+++ b/global_config.go
@@ -22,15 +22,11 @@ func setPortnumbers(base int) {
 	Ports.Summaries = base + 4
 }
 
-var githash = "githash not computed"
-var buildDate = "build date not computed"
-
 // BuildInfo can contain compile-time information about the build
 type BuildInfo struct {
-	Version  string
-	Githash  string
-	Date     string
-	RunStart time.Time
+	Version string
+	Githash string
+	Date    string
 }
 
 // Build is a global holding compile-time information about the build
@@ -40,7 +36,10 @@ var Build = BuildInfo{
 	Date:    "no build date computed",
 }
 
+// DastardStartTime is a global holding the time init() was run
+var DastardStartTime time.Time
+
 func init() {
 	setPortnumbers(5500)
-	Build.RunStart = time.Now()
+	DastardStartTime = time.Now()
 }

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -404,19 +404,35 @@ func (s *SourceControl) WriteControl(config *WriteControlConfig, reply *bool) er
 
 // StateLabelConfig is the argument type of SetExperimentStateLabel
 type StateLabelConfig struct {
-	Label string
+	Label        string
+	WaitForError bool // False (the default) will return ASAP and panic if there is an error
+	// True will wait for a response and return any error, but will be slower (~50 ms typical, slower possible)
 }
 
 // SetExperimentStateLabel sets the experiment state label in the _experiment_state file
 // The timestamp is fixed as soon as the RPC command is recieved
 func (s *SourceControl) SetExperimentStateLabel(config *StateLabelConfig, reply *bool) error {
 	timestamp := time.Now()
-	f := func() {
-		s.queuedResults <- s.ActiveSource.SetExperimentStateLabel(timestamp, config.Label)
+	if config.WaitForError {
+		f := func() {
+			s.queuedResults <- s.ActiveSource.SetExperimentStateLabel(timestamp, config.Label)
+		}
+		err := s.runLaterIfActive(f)
+		*reply = (err == nil)
+		return err
+	} else {
+		f := func() {
+			s.queuedResults <- s.ActiveSource.SetExperimentStateLabel(timestamp, config.Label)
+		}
+		f2 := func() {
+			err := s.runLaterIfActive(f)
+			if err != nil {
+				panic(fmt.Sprintf("error with WaitForError==false in SetExperimentStateLabel. %s", spew.Sdump(err)))
+			}
+		}
+		go f2()
+		return nil
 	}
-	err := s.runLaterIfActive(f)
-	*reply = (err == nil)
-	return err
 }
 
 // WriteComment writes the comment to comment.txt
@@ -572,7 +588,8 @@ func RunRPCServer(portrpc int, block bool) {
 	sourceControl.clientUpdates <- ClientUpdate{"NEWDASTARD", "new Dastard is running"}
 
 	// Load stored settings, and transfer saved configuration
-	// from Viper to relevant objects.
+	// from Viper to relevant objects. Note that these items are saved
+	// in client_updater.go
 	var okay bool
 	var spc SimPulseSourceConfig
 	log.Printf("Dastard is using config file %s\n", viper.ConfigFileUsed())

--- a/rpc_server_test.go
+++ b/rpc_server_test.go
@@ -235,7 +235,7 @@ func TestServer(t *testing.T) {
 			t.Errorf("want %q, have %q", "hello\n", *reply)
 		}
 	}
-	stateLabelArg := StateLabelConfig{Label: "testlabel"}
+	stateLabelArg := StateLabelConfig{Label: "testlabel", WaitForError: true}
 	if err1 := client.Call("SourceControl.SetExperimentStateLabel", &stateLabelArg, &okay); err1 != nil {
 		t.Error(err1)
 	}

--- a/writing_state.go
+++ b/writing_state.go
@@ -92,6 +92,7 @@ func (ws *WritingState) Stop() error {
 			return fmt.Errorf("failed to close externalTriggerFileWriter, err: %v", err)
 		}
 		ws.externalTriggerFileBufferedWriter = nil
+		ws.externalTriggerFile = nil
 	}
 	ws.externalTriggerNumberObserved = 0
 	ws.ExternalTriggerFilename = ""


### PR DESCRIPTION
The only substantial change here is to add a `WaitForError` argument to `SetExperimentStateLabel` which will default to `false`. With `WaitforError=false` the RPC call returns ASAP, and will later panic if there is an error. This way `SetExperimentStateLabel` will not hold up experimental control algorithms that wait for a response.