### PR TITLE
improve map info going to file headers

### DIFF
--- a/map.go
+++ b/map.go
@@ -33,13 +33,13 @@ func readMap(filename string) (*Map, error) {
 	if _, err := fmt.Fscanf(file, "spacing: %d\n", &m.Spacing); err != nil {
 		return nil, err
 	}
-
+	var matterChannums bool
 	for {
 		var chnum int
 		var p Pixel
 		_, err := fmt.Fscanf(file, "%d %d %d %s", &chnum, &p.X, &p.Y, &p.Name)
 		if err == io.EOF {
-			return m, nil
+			break
 		}
 		if err != nil {
 			fmt.Println(m)
@@ -47,7 +47,29 @@ func readMap(filename string) (*Map, error) {
 			return m, err
 		}
 		m.Pixels = append(m.Pixels, p)
+		if len(m.Pixels) == 2 {
+			if chnum == 3 {
+				matterChannums = true
+				fmt.Println("reading map with matter style channel numbers in legacy mode")
+			}
+		}
+		if len(m.Pixels) > 2 {
+			if matterChannums {
+				matterChannum := 2*len(m.Pixels) - 1
+				if chnum != matterChannum {
+					return nil, fmt.Errorf("readMap: have chnum %v, want matterChannum %v (matter channel number legacy mode)", chnum, matterChannum)
+				}
+			} else {
+				channelNumber := len(m.Pixels)
+				if chnum != channelNumber {
+					return nil, fmt.Errorf("readMap: have chnum %v, want channelNumber %v", chnum, channelNumber)
+
+				}
+			}
+		}
+
 	}
+	return m, nil
 }
 
 // MapServer is the RPC service that loads and broadcasts TES maps

--- a/map_test.go
+++ b/map_test.go
@@ -6,7 +6,7 @@ func TestMap(t *testing.T) {
 	fname := "maps/ar14_30rows_map.cfg"
 	m, err := readMap(fname)
 	if err != nil {
-		t.Errorf("Could not read map %q: %v", fname, err)
+		t.Fatalf("Could not read map %q: %v", fname, err)
 	}
 	if m.Spacing != 520 {
 		t.Errorf("map.Spacing=%d, want 520", m.Spacing)

--- a/rpc_server_test.go
+++ b/rpc_server_test.go
@@ -212,10 +212,14 @@ func TestServer(t *testing.T) {
 	if err != nil {
 		t.Fatal("Could not open temporary directory")
 	}
-	defer os.RemoveAll(path)
+	defer os.RemoveAll(path) // clean up test files
 	wconfig := WriteControlConfig{Request: "Start", Path: path, WriteLJH22: true}
+	// we currently have a 240 channel map loaded, but only have 4 channels, so this should error and invalidate the map file
+	if err1 := client.Call("SourceControl.WriteControl", &wconfig, &okay); err1 == nil {
+		t.Error("expected an error because we should have a 240 channel map loaded instead of a 4 channel map", err1)
+	}
 	if err1 := client.Call("SourceControl.WriteControl", &wconfig, &okay); err1 != nil {
-		t.Error("SourceControl.WriteControl START error:", err1)
+		t.Error("map should have been invalidated, so this should work")
 	}
 	if err1 := client.Call("SourceControl.ConfigurePulseLengths", &sizes, &okay); err1 == nil {
 		t.Errorf("Expected error calling SourceControl.ConfigurePulseLengths(%v) when writing active, saw none", sizes)


### PR DESCRIPTION
This is an attempt to improve the map file info going to file headers. It at least shouldn't crash (erring instead). If it errors due to wrong map size, it will invalidate the map so that the next attempt to start writing will work, just without a map.