### PR TITLE
Update install instructions and the make install target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,3 @@ go:
   - 1.14.x
 
 go_import_path: github.com/usnistgov/dastard
-
-addons:
-  apt:
-    sources:
-    - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_16.04/ ./'
-      key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_16.04/Release.key'
-    packages:
-    - libczmq-dev libzmq3-dev libsodium-dev

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 GOCMD=go
+GOGET=$(GOCMD) get
 GOBUILD=$(GOCMD) build
 GOCLEAN=$(GOCMD) clean
 GOTEST=$(GOCMD) test
-GOGET=$(GOCMD) get
 BINARY_NAME=dastard
 
 LDFLAGS=-ldflags "-X main.buildDate=$(shell date -u '+%Y-%m-%d.%I:%M:%S.%p.%Z') -X main.githash=$(shell git rev-parse HEAD)"
-all: test build
+all: test build install
 build: $(BINARY_NAME)
 
 $(BINARY_NAME): *.go cmd/dastard/dastard.go getbytes/*.go lancero/*.go ljh/*.go off/*.go packets/*.go ringbuffer/*.go
@@ -26,4 +26,5 @@ run: build
 deps:
 	$(GOGET) -v -t ./...
 
-install: deps
+install: build
+	cp -p $(BINARY_NAME) `go env GOPATH`/bin/

--- a/README.md
+++ b/README.md
@@ -3,45 +3,44 @@
 
 A data acquisition framework for NIST transition-edge sensor (TES) microcalorimeters. Designed to replace the earlier programs `ndfb_server` and `matter` (see their [bitbucket repository](https://bitbucket.org/nist_microcal/nasa_daq)).
 
-# Installation
-Requires golang version >1.13.
+## Installation
+Requires Go version 1.13 or higher. It is tested automatically on 1.13 and 1.14.
 
-## Ubuntu 18
-You need to paste at least the first line sepeartatley to have a chance to enter the sudo password, unless you already have sudo on.
+### Ubuntu 18.04 and 16.04
+One successful installation of the dependencies looked like this. Before pasting the following, be sure to run some
+simple command as sudo first; otherwise, the password entering step will screw up your multi-line paste.
 ```
-# dependencies
+# Dependencies (can skip if git is already installed)
 sudo apt-get -y update
 sudo apt-get install -y git
-# install go
+
+# Install golang (can skip if go version 1.13+ is already installed)
 sudo add-apt-repository -y ppa:longsleep/golang-backports
 sudo apt-get -y update
 sudo apt-get -y install golang-go
-# install Dastard
+
+# Install Dastard
 go get -v -u github.com/usnistgov/dastard
 cd ~/go/src/github.com/usnistgov/dastard/
 make
-sudo ln -s ~/go/src/github.com/usnistgov/dastard/dastard /usr/local/bin
+
+# Now add the go bin directory (typically, ~/go/bin) to your PATH. You should do the following
+# in your .bashrc, as well as at the shell prompt (to get immediate effect).
+export PATH=$PATH:`go env GOPATH`/bin
 ```
 
-## Ubuntu 16 Dependencies
-Replace the dependencies step with this
 
- ```
-sudo add-apt-repository -y 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-stable/xUbuntu_16.04/ ./'
-cd ~/Downloads
-wget http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-stable/xUbuntu_16.04/Release.key
-sudo apt-key add - < Release.key
-sudo apt-get -y update
-sudo apt-get install -y git
-
+### MacOS Dependencies
+Get golang version 1.13 or higher, with MacPorts or homebrew, or by direct download. For Ports, assuming that MacPorts
+is already installed, it's simple:
 ```
-
-## MacOS Dependencies
+sudo port install go
 ```
-get golang version >1.13, like macports or brew. write down how you did it here
-```
+As of April 20, 2020, this gets you go 1.14.2. If you use another method, please add notes here to help other users.
 
-## Also Install These
+
+
+### Also Install These
 
 * Install microscope https://github.com/usnistgov/microscope
 * Install dastard_commander https://github.com/usnistgov/dastard_commander

--- a/README.md
+++ b/README.md
@@ -24,15 +24,17 @@ go get -v -u github.com/usnistgov/dastard
 cd ~/go/src/github.com/usnistgov/dastard/
 make
 
-# Now add the go bin directory (typically, ~/go/bin) to your PATH. You should do the following
-# in your .bashrc, as well as at the shell prompt (to get immediate effect).
-export PATH=$PATH:`go env GOPATH`/bin
+# Check whether the GOPATH is in your bash path. If not, update ~/.bashrc to make it so.
+# This will fix the current terminal and all that run ~/.bashrc in the future, but not
+# any other existing terminals (until you do "source ~/.bashrc" in them).
+source update-path.sh
 ```
 
 
 ### MacOS Dependencies
-Get golang version 1.13 or higher, with MacPorts or homebrew, or by direct download. For Ports, assuming that MacPorts
-is already installed, it's simple:
+
+Get go version 1.13 or higher, with MacPorts or homebrew, or by direct download. For Ports, assuming
+that MacPorts is already installed, it's simple:
 ```
 sudo port install go
 ```

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,9 @@
 ## DASTARD Versions
 
+**0.2.7** in progress in April 2020
+* Use package `zmq4`, a pure Go implementation of ZMQ.
+* Simplified testing on Travis because of that.
+
 **0.2.6** April 2, 2020
 * Change handling of data drops.
 * Generate OFF files v0.3.0, with pretrigger Deltas.

--- a/global_config.go
+++ b/global_config.go
@@ -31,7 +31,7 @@ type BuildInfo struct {
 
 // Build is a global holding compile-time information about the build
 var Build = BuildInfo{
-	Version: "0.2.6",
+	Version: "0.2.7",
 	Githash: "no git hash computed",
 	Date:    "no build date computed",
 }

--- a/update-path.sh
+++ b/update-path.sh
@@ -1,0 +1,20 @@
+# Check that you have your go path in the bash PATH.
+# Use this by sourcing the current file:
+# source update-path.sh
+
+dir=`go env GOPATH`/bin
+BASHRC=$HOME/.bashrc
+
+if [ `echo :$PATH: | grep -F :$dir:` ]; then
+   echo "$dir is already in the UNIX path"
+else
+   echo "$dir is not in the UNIX path. Updating \$PATH and $BASHRC"
+   echo >> $BASHRC
+   echo "# Updated by Dastard package update-path.sh" >> $BASHRC
+   echo "export PATH=\$PATH:$dir" >> $BASHRC
+   export PATH=$PATH:$dir
+   echo $PATH
+fi
+
+unset dir
+unset BASHRC


### PR DESCRIPTION
1. Updated the installation instructions on the READMe.
1. Improved the `make install` so it installs the binary with our version tag and git hash built in.
1. Simplified (and sped up) the Travis CI testing now that we are using a pure-go ZMQ implementation. Because of this, we don't need to install the obscure non-go dependencies of czmq and libzmq3 and libsodium.