### PR TITLE
Don't discard partial packets when emptying ring buffer

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -3,6 +3,7 @@
 **0.2.7** in progress in April 2020
 * Use package `zmq4`, a pure Go implementation of ZMQ.
 * Simplified testing on Travis because of that.
+* Read Abaco packets correctly when fractional packets are in ring buffer (issue 188).
 
 **0.2.6** April 2, 2020
 * Change handling of data drops.

--- a/ringbuffer/ringbuffer.go
+++ b/ringbuffer/ringbuffer.go
@@ -281,10 +281,20 @@ func (rb *RingBuffer) BytesReadable() int {
 	return int(w - r)
 }
 
-// DiscardAll removes all readable bytes and empties the buffer.
-func (rb *RingBuffer) DiscardAll() (err error) {
-	rb.desc.readPointer = rb.desc.writePointer
+// DiscardStride removes readable bytes up to a multiple of stride. This empties the buffer except
+// for a runt section with size less than stride bytes long
+func (rb *RingBuffer) DiscardStride(stride uint64) (err error) {
+	newRp := rb.desc.writePointer
+	if newRp % stride > 0 {
+		newRp -= newRp % stride
+	}
+	rb.desc.readPointer = newRp
 	return nil
+}
+
+// DiscardAll removes all readable bytes, which empties the buffer.
+func (rb *RingBuffer) DiscardAll() (err error) {
+	return rb.DiscardStride(1)
 }
 
 // PacketSize returns the packetSize held in the buffer description

--- a/ringbuffer/ringbuffer_test.go
+++ b/ringbuffer/ringbuffer_test.go
@@ -154,6 +154,19 @@ func TestBufferWriteRead(t *testing.T) {
 			expect, len(data), 0)
 	}
 
+	// Now put bytes in the buffer, use DiscardStride, and verify that the remaining size is what we expect.
+	writebuf.Write(deadbeef)
+	writes := 3  //  because we've written deadbeef 3 times now.
+	wantRump := 1000
+	b.DiscardStride(uint64(writes*expect-wantRump))
+	data, err = b.Read(expect)
+	if err != nil {
+		t.Errorf("Failed to b.Read(%d) when nearly empty", expect)
+	} else if len(data) != wantRump {
+		t.Errorf("b.Read(%d) after DiscardStride(%d) returned len(data)=%d, want %d",
+			expect, writes*expect-wantRump, len(data), wantRump)
+	}
+
 	// Now put different bytes in the buffer, verify that they are the right values.
 	writebuf.Write(bead5678)
 	readable = b.BytesReadable()


### PR DESCRIPTION
Fixes #188. This is necessary because of how Mazsi's program `circbtest` fills packets into the ring buffer in chunks smaller than the packet size.