### PR TITLE
Handle Abaco channel groups as mostly independent experiments.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ dist: xenial
 sudo: required
 
 go:
-  - 1.10.x  # This should stay at 1.10, as Go 1.10 is the default in Ubuntu 18.04.
-  - 1.15.x  # This should be the newest Go release
+  # Test Go versions 1.13 and the most recent. Assume that in-between also works!
+  - 1.13.x  # This should stay at 1.13, as gonum supports only 1.13+
+  - 1.15.x  # This should track the lastest Go release (1.15 came out 10 Aug 2020)
 
 go_import_path: github.com/usnistgov/dastard
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ dist: xenial
 sudo: required
 
 go:
-  - 1.13.x
-  - 1.14.x
+  - 1.10.x  # This should stay at 1.10, as Go 1.10 is the default in Ubuntu 18.04.
+  - 1.15.x  # This should be the newest Go release
 
 go_import_path: github.com/usnistgov/dastard
 
@@ -16,4 +16,3 @@ addons:
       key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_16.04/Release.key'
     packages:
     - libczmq-dev libzmq3-dev libsodium-dev
-    

--- a/README.md
+++ b/README.md
@@ -37,16 +37,13 @@ wget http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-s
 sudo apt-key add - < Release.key
 sudo apt-get -y update
 sudo apt-get install -y libsodium-dev libczmq-dev git
+```
 
 Get go version 1.13 or higher, with MacPorts or homebrew, or by direct download. For Ports, assuming
 that MacPorts is already installed, it's simple:
-```
 
 ## MacOS Dependencies
-```
 get libsodium-dev and libczmq-dev and golang version >1.13, like macports or brew. write down how you did it here
-```
-As of April 20, 2020, this gets you go 1.14.2. If you use another method, please add notes here to help other users.
 
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 A data acquisition framework for NIST transition-edge sensor (TES) microcalorimeters. Designed to replace the earlier programs `ndfb_server` and `matter` (see their [bitbucket repository](https://bitbucket.org/nist_microcal/nasa_daq)).
 
 ## Installation
-Requires Go version 1.13 or higher. It is tested automatically on 1.13 and 1.14.
+Requires Go version 1.13 or higher because [gonum](http://gonum.org/v1/gonum/mat) requires it. Dastard is tested automatically on versions 1.13 and 1.15 (as of August 2020, Go version 1.15 is the most recent).
 
 ### Ubuntu 18.04 and 16.04
 One successful installation of the dependencies looked like this. Before pasting the following, be sure to run some

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -3,9 +3,13 @@
 **0.2.7** in progress in April 2020
 * Use package `zmq4`, a pure Go implementation of ZMQ.
 * Simplified testing on Travis because of that.
-* Then revert to `gozmq` because `zmq4` was dropping packets. (Fixes 192)
+* Then revert to `gozmq` because `zmq4` was dropping packets (issue 192).
 * Read Abaco packets correctly when fractional packets are in ring buffer (issue 188).
 * Fix CurrentTime client message to be valid JSON (issue 194).
+* Added program Bahama to generate fake Abaco packet-style data (issues 196, 200).
+* Fix problem where ZMQ 2-part messages were sent w/o checking for errors (issue 198).
+* Handle Abaco packets from separate channel groups as independent (issue 190).
+* Fill in fake data when any Abaco packets are missing (issue 202).
 
 **0.2.6** April 2, 2020
 * Change handling of data drops.

--- a/abaco.go
+++ b/abaco.go
@@ -340,7 +340,10 @@ func (device *AbacoRing) samplePackets() (allPackets []*packets.Packet, err erro
 
 	// Now get the data we actually want: fresh data. Run for at least
 	// a minimum time or a minimum number of packets.
-	const minPacketsToRead = 100 // Not sure this is a good minimum?
+	// The hard requirement is for at least 2 packets per channel group, so we can count samples taken
+	// between 2 timestamps and thus the sample rate. More packets is better, because we can estimate
+	// sample rate over a longer baseline, we are less likely to overlook a channel group.
+	const minPacketsToRead = 100 // Is this a good minimum? If we start missing channel groups, increase this.
 	maxSampleTime := time.Duration(2000 * time.Millisecond)
 	timeOut := time.NewTimer(maxSampleTime)
 

--- a/abaco.go
+++ b/abaco.go
@@ -346,7 +346,6 @@ type AbacoSource struct {
 	arings map[int]*AbacoRing
 	active []*AbacoRing
 
-	nchan  int
 	groups map[GroupIndex]*AbacoGroup
 	groupKeysSorted []GroupIndex
 
@@ -447,7 +446,6 @@ func (as *AbacoSource) distributePackets(allpackets []*packets.Packet, now time.
 
 // Sample determines key data facts by sampling some initial data.
 func (as *AbacoSource) Sample() error {
-	as.nchan = 0
 	if len(as.active) <= 0 {
 		return fmt.Errorf("No Abaco ring buffers are active")
 	}

--- a/abaco_test.go
+++ b/abaco_test.go
@@ -78,15 +78,15 @@ func TestGeneratePackets(t *testing.T) {
 	}
 }
 
-func TestAbacoDevice(t *testing.T) {
-	if _, err := NewAbacoDevice(99999); err == nil {
-		t.Errorf("NewAbacoDevice(99999) succeeded, want failure")
+func TestAbacoRing(t *testing.T) {
+	if _, err := NewAbacoRing(99999); err == nil {
+		t.Errorf("NewAbacoRing(99999) succeeded, want failure")
 	}
 	rand.Seed(time.Now().UnixNano())
 	cardnum := -rand.Intn(99998) - 1 // Rand # between -1 and -99999
-	dev, err := NewAbacoDevice(cardnum)
+	dev, err := NewAbacoRing(cardnum)
 	if err != nil {
-		t.Fatalf("NewAbacoDevice(%d) fails: %s", cardnum, err)
+		t.Fatalf("NewAbacoRing(%d) fails: %s", cardnum, err)
 	}
 
 	ringname := fmt.Sprintf("xdma%d_c2h_0_buffer", cardnum)
@@ -101,7 +101,7 @@ func TestAbacoDevice(t *testing.T) {
 		t.Fatalf("Failed RingBuffer.Create: %s", err)
 	}
 
-	go dev.sampleCard()
+	go dev.samplePackets()
 
 	p := packets.NewPacket(10, 20, 0x100, 0)
 	const Nchan = 8
@@ -156,12 +156,12 @@ func TestAbacoSource(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	cardnum := -rand.Intn(99998) - 1 // Rand # between -1 and -99999
 
-	dev, err := NewAbacoDevice(cardnum)
+	dev, err := NewAbacoRing(cardnum)
 	if err != nil {
-		t.Fatalf("NewAbacoDevice(%d) fails: %s", cardnum, err)
+		t.Fatalf("NewAbacoRing(%d) fails: %s", cardnum, err)
 	}
-	source.devices[cardnum] = dev
-	source.Ndevices++
+	source.arings[cardnum] = dev
+	source.Nrings++
 
 	deviceCodes := []int{cardnum}
 	var config AbacoSourceConfig

--- a/abaco_test.go
+++ b/abaco_test.go
@@ -225,9 +225,9 @@ func TestAbacoSource(t *testing.T) {
 			case <-timer.C:
 				for i := 0; i < Nsamp; i += stride {
 					p.NewData(d[i:i+stride*Nchan], dims)
-					// Skip every 50th packet
+					// Skip 2 packets of every 46
 					packetcount++
-					if packetcount % 50 == 0 {
+					if packetcount % 46 < 2 {
 						continue
 					}
 					b := p.Bytes()
@@ -248,10 +248,10 @@ func TestAbacoSource(t *testing.T) {
 		fmt.Printf("Result of Start(source,...): %s\n", err)
 		t.Fatal(err)
 	}
-	// if dev.nchan != Nchan {
-	// 	t.Errorf("dev.nchan=%d, want %d", dev.nchan, Nchan)
-	// }
-	time.Sleep(150 * time.Millisecond)
+	if source.nchan != Nchan {
+		t.Errorf("source.nchan=%d, want %d", source.nchan, Nchan)
+	}
+	time.Sleep(250 * time.Millisecond)
 	source.Stop()
 	close(abortSupply)
 	source.RunDoneWait()

--- a/abaco_test.go
+++ b/abaco_test.go
@@ -217,13 +217,19 @@ func TestAbacoSource(t *testing.T) {
 		empty := make([]byte, packetAlign)
 		dims := []int16{Nchan}
 		timer := time.NewTicker(10 * time.Millisecond)
-		for {
+		packetcount := 0
+		for ;; {
 			select {
 			case <-abortSupply:
 				return
 			case <-timer.C:
 				for i := 0; i < Nsamp; i += stride {
 					p.NewData(d[i:i+stride*Nchan], dims)
+					// Skip every 50th packet
+					packetcount++
+					if packetcount % 50 == 0 {
+						continue
+					}
 					b := p.Bytes()
 					b = append(b, empty[:packetAlign-len(b)]...)
 					if rb.BytesWriteable() >= len(b) {

--- a/abaco_test.go
+++ b/abaco_test.go
@@ -205,7 +205,7 @@ func TestAbacoSource(t *testing.T) {
 
 	abortSupply := make(chan interface{})
 	supplyDataForever := func() {
-		p := packets.NewPacket(10, 20, 0x100, 0)
+		p := packets.NewPacket(10, 20, 100, 0)
 		d := make([]int16, Nchan*Nsamp)
 		for i := 0; i < Nchan; i++ {
 			freq := (float64(i + 2)) / float64(Nsamp)
@@ -225,9 +225,9 @@ func TestAbacoSource(t *testing.T) {
 			case <-timer.C:
 				for i := 0; i < Nsamp; i += stride {
 					p.NewData(d[i:i+stride*Nchan], dims)
-					// Skip 2 packets of every 46
+					// Skip 2 packets of every 80, the 1st and 80th.
 					packetcount++
-					if packetcount % 46 < 2 {
+					if packetcount % 80 < 2 {
 						continue
 					}
 					b := p.Bytes()

--- a/client_updater.go
+++ b/client_updater.go
@@ -26,21 +26,20 @@ type ClientUpdate struct {
 // nopublishMessages is a set of message names that you don't send to clients, because they
 // contain no configuration that makes sense for clients to hear.
 var nopublishMessages = map[string]struct{}{
-	"CURRENTTIME":    {},
+	"CURRENTTIME": {},
 }
 
 // nologMessages is a set of message names that you don't log to the terminal, because they
 // are too long or too frequent to bother with.
 var nologMessages = map[string]struct{}{
-	"TRIGGERRATE":    {},
+	"TRIGGERRATE":     {},
 	"CHANNELNAMES":    {},
-	"ALIVE":    {},
-	"NUMBERWRITTEN":    {},
-	"EXTERNALTRIGGER":    {},
+	"ALIVE":           {},
+	"NUMBERWRITTEN":   {},
+	"EXTERNALTRIGGER": {},
 }
 
 // var messageSerial int
-
 
 // publish sends to all clients of the status update socket a 2-part message, with
 // the `update.tag` as the first part and `message` as the second. The latter should be

--- a/data_source.go
+++ b/data_source.go
@@ -280,7 +280,7 @@ type AnySource struct {
 }
 
 // SamplePeriod returns the sample period of the underlying source.
-func (ds *AnySource) SamplePeriod() (time.Duration) {
+func (ds *AnySource) SamplePeriod() time.Duration {
 	return ds.samplePeriod
 }
 

--- a/lancero/no_hardware.go
+++ b/lancero/no_hardware.go
@@ -126,7 +126,7 @@ func (lan *NoHardware) AvailableBuffer() ([]byte, time.Time, error) {
 	frameDurationNanoseconds := lan.linePeriod * lan.nsPerLinePeriod * lan.nrows
 	frames := int(sinceLastRead.Nanoseconds()) / frameDurationNanoseconds
 	// log.Printf("id %v read at %v\n", lan.idNum, time.Now())
-	if sinceLastRead > 50*lan.minTimeBetweenReads {
+	if sinceLastRead > 100*lan.minTimeBetweenReads {
 		return buf.Bytes(), now, fmt.Errorf("reads were %v apart, want < %v", sinceLastRead, 50*lan.minTimeBetweenReads)
 	}
 

--- a/packets/packets.go
+++ b/packets/packets.go
@@ -145,6 +145,29 @@ func (p *Packet) ResetTimestamp() error {
 	return nil
 }
 
+// MakePretendPacket generates a copy of p with the given sequence number
+// and with the given value for the whole data payload.
+// Use it for making fake data to fill in where packets were dropped.
+func (p *Packet) MakePretendPacket(seqnum uint32, value int) (*Packet) {
+	pretend := *p
+	pretend.sequenceNumber = seqnum
+	switch d := pretend.Data.(type) {
+	case []int16:
+		for i := range(d) {
+			d[i] = int16(value)
+		}
+	case []int32:
+		for i := range(d) {
+			d[i] = int32(value)
+		}
+	case []int64:
+		for i := range(d) {
+			d[i] = int64(value)
+		}
+	}
+	return &pretend
+}
+
 // NewData adds data to the packet, and creates the format and shape TLV items to match.
 func (p *Packet) NewData(data interface{}, dims []int16) error {
 	ndim := len(dims)

--- a/packets/packets.go
+++ b/packets/packets.go
@@ -168,6 +168,23 @@ func (p *Packet) MakePretendPacket(seqnum uint32, value int) (*Packet) {
 	return &pretend
 }
 
+// ReadValue returns a single sample from the packet's data payload.
+// Not efficient for reading the whole data slice.
+func (p *Packet) ReadValue(sample int) int {
+	if sample < 0 || sample >= p.Frames() {
+		return 0
+	}
+	switch d := p.Data.(type) {
+	case []int16:
+		return int(d[sample])
+	case []int32:
+		return int(d[sample])
+	case []int64:
+		return int(d[sample])
+	}
+	return 0
+}
+
 // NewData adds data to the packet, and creates the format and shape TLV items to match.
 func (p *Packet) NewData(data interface{}, dims []int16) error {
 	ndim := len(dims)

--- a/packets/packets_test.go
+++ b/packets/packets_test.go
@@ -407,6 +407,41 @@ func TestFullPackets(t *testing.T) {
 		if ts := pread.Timestamp(); ts != nil {
 			t.Errorf("ReadPacket.Timestamp() yielded %v, expected nil", ts)
 		}
+
+		// Test PretendPacket
+		arbSeqNum := uint32(34567)
+		arbVal := 48
+		pfake := p.MakePretendPacket(arbSeqNum, arbVal)
+		if pfake == p {
+			t.Errorf("PretendPacket() result points to original packet")
+		}
+		if arbSeqNum != pfake.SequenceNumber() {
+			t.Errorf("PretendPacket(%d) result has seq num %d, want %d", arbSeqNum,
+				pfake.SequenceNumber(), arbSeqNum)
+		}
+		switch d := pfake.Data.(type) {
+		case []int16:
+			want := int16(arbVal)
+			for i, v := range d {
+				if v != want {
+					t.Errorf("PretendPacket.Data[%d]=%d, want %d", i, v, want)
+				}
+			}
+		case []int32:
+			want := int32(arbVal)
+			for i, v := range d {
+				if v != want {
+					t.Errorf("PretendPacket.Data[%d]=%d, want %d", i, v, want)
+				}
+			}
+		case []int64:
+			want := int64(arbVal)
+			for i, v := range d {
+				if v != want {
+					t.Errorf("PretendPacket.Data[%d]=%d, want %d", i, v, want)
+				}
+			}
+		}
 	}
 
 	p.ClearData()

--- a/packets/packets_test.go
+++ b/packets/packets_test.go
@@ -413,34 +413,22 @@ func TestFullPackets(t *testing.T) {
 		arbVal := 48
 		pfake := p.MakePretendPacket(arbSeqNum, arbVal)
 		if pfake == p {
-			t.Errorf("PretendPacket() result points to original packet")
+			t.Errorf("MakePretendPacket() result points to original packet")
 		}
 		if arbSeqNum != pfake.SequenceNumber() {
-			t.Errorf("PretendPacket(%d) result has seq num %d, want %d", arbSeqNum,
+			t.Errorf("MakePretendPacket(%d) result has seq num %d, want %d", arbSeqNum,
 				pfake.SequenceNumber(), arbSeqNum)
 		}
-		switch d := pfake.Data.(type) {
-		case []int16:
-			want := int16(arbVal)
-			for i, v := range d {
-				if v != want {
-					t.Errorf("PretendPacket.Data[%d]=%d, want %d", i, v, want)
-				}
+		nsamp := pfake.Frames()
+		for i := 0; i<nsamp; i++ {
+			v := pfake.ReadValue(i)
+			if v != arbVal {
+				t.Errorf("Packet.ReadValue(%d)=%d, want %d", i, v, arbVal)
 			}
-		case []int32:
-			want := int32(arbVal)
-			for i, v := range d {
-				if v != want {
-					t.Errorf("PretendPacket.Data[%d]=%d, want %d", i, v, want)
-				}
-			}
-		case []int64:
-			want := int64(arbVal)
-			for i, v := range d {
-				if v != want {
-					t.Errorf("PretendPacket.Data[%d]=%d, want %d", i, v, want)
-				}
-			}
+		}
+		v := pfake.ReadValue(-1)
+		if v != 0 {
+			t.Errorf("Packet.ReadValue(-1)=%d, want 0", v)
 		}
 	}
 

--- a/phase_unwrap_test.go
+++ b/phase_unwrap_test.go
@@ -30,7 +30,7 @@ func TestUnwrap(t *testing.T) {
 		}
 		// Test unwrap on sawtooth of 4 steps
 		// Result should be a line.
-		step := 1 << (fractionbits-2)
+		step := 1 << (fractionbits - 2)
 		mod := step * 4
 		for i := 0; i < ndata; i++ {
 			data[i] = RawType((i * step) % mod)

--- a/process_data.go
+++ b/process_data.go
@@ -200,7 +200,7 @@ func (dsp *DataStreamProcessor) AnalyzeData(records []*DataRecord) {
 		// slope = dot(x,y.-y[0])/z where z = dot(x,x) and x = [0, 1, 2, ..., N-1]/(N-1), where .-y[0] is elementwise subtraction of the first element
 		npre := rec.presamples
 		d0 := dataVec.AtVec(0)
-		xmean := float64(npre-1)*0.5
+		xmean := float64(npre-1) * 0.5
 		for i := 0; i < npre; i++ {
 			val += dataVec.AtVec(i)
 			valPTDelta += (dataVec.AtVec(i) - d0) * (float64(i) - xmean)

--- a/process_data_test.go
+++ b/process_data_test.go
@@ -85,22 +85,22 @@ func TestAnalyzePre(t *testing.T) {
 	slopes := []float64{0, 1, 5, -2, -50, 0.333333, 1.5, 10.94}
 	firsts := []float64{40, 100, 1000}
 	npres := []int{4, 7, 13}
-	for _, npre := range(npres) {
-		for _, m := range(slopes) {
-			for _, b := range(firsts) {
+	for _, npre := range npres {
+		for _, m := range slopes {
+			for _, b := range firsts {
 				sum := 0.0
 				sumx := 0.0
 				sumxy := 0.0
 				sumx2 := 0.0
-				for j := 0; j<npre; j++ {
-					data[j] = RawType(b + m*float64(j)+0.5)
+				for j := 0; j < npre; j++ {
+					data[j] = RawType(b + m*float64(j) + 0.5)
 					sum += float64(data[j])
 					sumx += float64(j)
-					sumx2 += float64(j*j)
-					sumxy += float64(j)*float64(data[j])
+					sumx2 += float64(j * j)
+					sumxy += float64(j) * float64(data[j])
 				}
-				mean := sum/float64(npre)
-				regressSlope := (sumxy-sumx*sum/float64(npre))/(sumx2 - (sumx*sumx)/float64(npre))
+				mean := sum / float64(npre)
+				regressSlope := (sumxy - sumx*sum/float64(npre)) / (sumx2 - (sumx*sumx)/float64(npre))
 				rec := &DataRecord{data: data, presamples: npre}
 				records := []*DataRecord{rec}
 
@@ -108,8 +108,8 @@ func TestAnalyzePre(t *testing.T) {
 				dsp.AnalyzeData(records)
 
 				expect := RTExpect{
-					pretrigMean:    mean,
-					pretrigDelta:   regressSlope*float64(npre-1)}
+					pretrigMean:  mean,
+					pretrigDelta: regressSlope * float64(npre-1)}
 				testAnalyzePretrigCheck(t, rec, expect, "Analyze Pre")
 
 			}
@@ -241,11 +241,11 @@ func testAnalyzeCheck(t *testing.T, rec *DataRecord, expect RTExpect, name strin
 }
 
 func testAnalyzePretrigCheck(t *testing.T, rec *DataRecord, expect RTExpect, name string) {
-	if math.Abs(rec.pretrigMean - expect.pretrigMean) > 1e-7 && !(math.IsNaN(rec.pretrigMean) && math.IsNaN(expect.pretrigMean)) {
+	if math.Abs(rec.pretrigMean-expect.pretrigMean) > 1e-7 && !(math.IsNaN(rec.pretrigMean) && math.IsNaN(expect.pretrigMean)) {
 		t.Errorf("Pretrigger mean = %v, want %v", rec.pretrigMean, expect.pretrigMean)
 		t.Logf("%v\n", rec)
 	}
-	if math.Abs(rec.pretrigDelta - expect.pretrigDelta) > 1e-7 && !(math.IsNaN(rec.pretrigDelta) && math.IsNaN(expect.pretrigDelta)) {
+	if math.Abs(rec.pretrigDelta-expect.pretrigDelta) > 1e-7 && !(math.IsNaN(rec.pretrigDelta) && math.IsNaN(expect.pretrigDelta)) {
 		t.Errorf("Pretrigger delta = %v, want %v", rec.pretrigDelta, expect.pretrigDelta)
 		t.Logf("%v\n", rec)
 	}

--- a/publish_data.go
+++ b/publish_data.go
@@ -391,8 +391,7 @@ func startSocket(port int, converter func(*DataRecord) [][]byte) (chan []*DataRe
 				message := converter(record)
 				err := pubSocket.SendMessage(message)
 				if err != nil {
-					fmt.Println("zmq send error:", err)
-					// panic("zmq send error")
+					fmt.Println("zmq send error publishing a triggered record:", err)
 				}
 			}
 		}

--- a/roach.go
+++ b/roach.go
@@ -31,6 +31,7 @@ type RoachSource struct {
 
 const roachFractionBits = 14
 const roachBitsToDrop = 2
+
 // That is, ROACH data is of the form ii.bbbb bbbb bbbb bb with 2 integer bits
 // and 14 fractional bits. In the unwrapping process, we drop 2, making it 4/12.
 


### PR DESCRIPTION
Reworks how the `AbacoSource` handles "devices" (now, `AbacoRing` objects) and separates that from how it handles the channel groups (`AbacoGroup` objects). Packets from the former are distributed to the appropriate queue of the latter.

- Handles missing Abaco packets (by filling in dummy values).
- Achieves crude (~ms-scale?) synchronization between channel groups.
- Allows for channel numbering with (potentially large) gaps between numbers in successive groups.
- Fixes #190.
- Fixes #202.