### PR TITLE
Handle dropped data correctly, with logging

### DIFF
--- a/abaco.go
+++ b/abaco.go
@@ -146,8 +146,7 @@ func (group *AbacoGroup) fillMissingPackets() (numberAdded int) {
 	for _, p := range group.queue {
 		sn := p.SequenceNumber()
 		for snexpect < sn {
-			val := p.ReadValue(0) // Fill data with first sample from next non-missing packet
-			pfake := p.MakePretendPacket(snexpect, val)
+			pfake := p.MakePretendPacket(snexpect, group.nchan)
 			newq = append(newq, pfake)
 			numberAdded++
 			snexpect++

--- a/abaco.go
+++ b/abaco.go
@@ -639,8 +639,14 @@ awaitmoredata:
 			// in each group and trimming leading packets if any precede the others.
 			// Fill in for any missing packets first, so a missing first packet isn't a problem.
 			firstSn := uint32(0)
-			for _, group := range as.groups {
-				group.fillMissingPackets()
+			for idx, group := range as.groups {
+				numberAdded := group.fillMissingPackets()
+				if numberAdded > 0 && as.problemLogger != nil {
+					cfirst := idx.firstchan
+					clast := cfirst + idx.nchan - 1
+					as.problemLogger.Printf("AbacoGroup %v=channels [%d,%d] filled in %d missing packets", idx,
+						cfirst, clast, numberAdded)
+				}
 				sn0, err := group.firstSeqNum()
 				if err != nil { // That is, no data available from this group
 					continue awaitmoredata

--- a/abaco.go
+++ b/abaco.go
@@ -643,9 +643,8 @@ awaitmoredata:
 			for _, group := range as.groups {
 				group.fillMissingPackets()
 				sn0, err := group.firstSeqNum()
-				if err != nil {
-					msg := fmt.Sprintf("AbacoSource.Sample finds no packets for group %v: %v", group, err)
-					panic(msg)
+				if err != nil { // That is, no data available from this group
+					continue awaitmoredata
 				}
 				if sn0 > firstSn {
 					firstSn = sn0
@@ -660,6 +659,9 @@ awaitmoredata:
 				if nsamp < framesToDeMUX {
 					framesToDeMUX = nsamp
 				}
+			}
+			if framesToDeMUX <= 0 {
+				continue awaitmoredata
 			}
 
 			// Demux data into this slice of slices of RawType (reserve capacity=framesToDeMUX)

--- a/abaco.go
+++ b/abaco.go
@@ -641,10 +641,10 @@ awaitmoredata:
 			firstSn := uint32(0)
 			for idx, group := range as.groups {
 				numberAdded := group.fillMissingPackets()
-				if numberAdded > 0 && as.problemLogger != nil {
+				if numberAdded > 0 && ProblemLogger != nil {
 					cfirst := idx.firstchan
 					clast := cfirst + idx.nchan - 1
-					as.problemLogger.Printf("AbacoGroup %v=channels [%d,%d] filled in %d missing packets", idx,
+					ProblemLogger.Printf("AbacoGroup %v=channels [%d,%d] filled in %d missing packets", idx,
 						cfirst, clast, numberAdded)
 				}
 				sn0, err := group.firstSeqNum()

--- a/abaco_test.go
+++ b/abaco_test.go
@@ -218,7 +218,7 @@ func TestAbacoSource(t *testing.T) {
 		dims := []int16{Nchan}
 		timer := time.NewTicker(10 * time.Millisecond)
 		packetcount := 0
-		for ;; {
+		for {
 			select {
 			case <-abortSupply:
 				return
@@ -227,7 +227,7 @@ func TestAbacoSource(t *testing.T) {
 					p.NewData(d[i:i+stride*Nchan], dims)
 					// Skip 2 packets of every 80, the 1st and 80th.
 					packetcount++
-					if packetcount % 80 < 2 {
+					if packetcount%80 < 2 {
 						continue
 					}
 					b := p.Bytes()

--- a/cmd/abaco/bahama_test.go
+++ b/cmd/abaco/bahama_test.go
@@ -16,7 +16,7 @@ func TestHelpers(t *testing.T) {
 	mins := []float64{0, -10, 10}
 	maxs := []float64{2, 0, 20}
 	expect := []float64{1, 0, 10}
-	for i := range(mins) {
+	for i := range mins {
 		coerceFloat(&f, mins[i], maxs[i])
 		if f != expect[i] {
 			t.Errorf("coerceInt made f=%.4f, want %.4f", f, expect[i])
@@ -36,27 +36,27 @@ func TestInterleave(t *testing.T) {
 	// First test interleaved, non-staggered packets
 	c1 := make([]chan []byte, ngroup)
 	p := make([][]byte, ngroup)
-	for i := 0; i<ngroup; i++ {
+	for i := 0; i < ngroup; i++ {
 		c1[i] = make(chan []byte)
 		p[i] = []byte{byte(i)}
 	}
 	c2 := make(chan []byte)
 	go interleavePackets(c2, c1, false)
 
-	for j := 0; j<ngroup; j++ {
+	for j := 0; j < ngroup; j++ {
 		go func(cid int) {
-			for i := 0; i<npackets; i++ {
+			for i := 0; i < npackets; i++ {
 				c1[cid] <- p[cid]
 			}
 			close(c1[cid])
 		}(j)
 	}
-	for i := 0; i<npackets*ngroup; i++ {
+	for i := 0; i < npackets*ngroup; i++ {
 		pi, ok := <-c2
 		if !ok {
 			t.Errorf("Expected %d non-staggered packets before output channel closed, got %d", npackets*ngroup, i)
 		}
-		expect := byte((i/4) % ngroup)
+		expect := byte((i / 4) % ngroup)
 		if pi[0] != expect {
 			t.Errorf("Non-staggered interleave packet %3d source is %d, want %d", i, pi[0], expect)
 		}
@@ -67,21 +67,21 @@ func TestInterleave(t *testing.T) {
 
 	// Now test staggered, interleaved packets
 	c1 = make([]chan []byte, ngroup)
-	for i := 0; i<ngroup; i++ {
+	for i := 0; i < ngroup; i++ {
 		c1[i] = make(chan []byte)
 	}
 	c2 = make(chan []byte)
 	go interleavePackets(c2, c1, true)
-	for j := 0; j<ngroup; j++ {
+	for j := 0; j < ngroup; j++ {
 		go func(cid int) {
-			for i := 0; i<npackets; i++ {
+			for i := 0; i < npackets; i++ {
 				c1[cid] <- p[cid]
 			}
 			close(c1[cid])
 		}(j)
 	}
-	expectby4 := []byte{0,1,1,2,2,2,0,0,0,1,1,1,2,2,2,0,0,0,1,1,2}
-	for i := 0; i<npackets*ngroup; i++ {
+	expectby4 := []byte{0, 1, 1, 2, 2, 2, 0, 0, 0, 1, 1, 1, 2, 2, 2, 0, 0, 0, 1, 1, 2}
+	for i := 0; i < npackets*ngroup; i++ {
 		pi, ok := <-c2
 		if !ok {
 			t.Errorf("Expected %d staggered packets before output channel closed, got %d", npackets*ngroup, i)
@@ -103,8 +103,8 @@ func TestGenerate(t *testing.T) {
 		time.Sleep(40 * time.Millisecond)
 		close(cancel)
 	}()
-	control := BahamaControl{Nchan:4, Ngroups:1, sinusoid:true, sawtooth:true, pulses:true,
-		noiselevel:5.0, samplerate:100000}
+	control := BahamaControl{Nchan: 4, Ngroups: 1, sinusoid: true, sawtooth: true, pulses: true,
+		noiselevel: 5.0, samplerate: 100000}
 	ch := make(chan []byte)
 	err := generateData(control.Nchan, 0, ch, cancel, control)
 	if err != nil {

--- a/cmd/dastard/dastard.go
+++ b/cmd/dastard/dastard.go
@@ -94,6 +94,8 @@ func main() {
 		panic(err)
 	}
 
+	makeFileExist("$HOME/.dastard/logs", "problems.log")
+
 	abort := make(chan struct{})
 	go dastard.RunClientUpdater(dastard.Ports.Status, abort)
 	dastard.RunRPCServer(dastard.Ports.RPC, true)

--- a/cmd/dastard/dastard.go
+++ b/cmd/dastard/dastard.go
@@ -18,7 +18,7 @@ var buildDate = "build date not computed"
 
 // makeFileExist checks that dir/filename exists, and creates the directory
 // and file if it doesn't.
-func makeFileExist(dir, filename string) (string,  error) {
+func makeFileExist(dir, filename string) (string, error) {
 	// Replace 1 instance of "$HOME" in the path with the actual home directory.
 	if strings.Contains(dir, "$HOME") {
 		home, err := os.UserHomeDir()
@@ -83,15 +83,14 @@ func startProblemLogger(pfname string) *log.Logger {
 	}
 	probLogger := log.New(probFile, "", log.LstdFlags)
 	probLogger.SetOutput(&lumberjack.Logger{
-	    Filename:   pfname,
-	    MaxSize:    10,  // megabytes after which new file is created
-	    MaxBackups: 5,    // number of backups
-	    MaxAge:     365,  // days
+		Filename:   pfname,
+		MaxSize:    10,   // megabytes after which new file is created
+		MaxBackups: 5,    // number of backups
+		MaxAge:     365,  // days
 		Compress:   true, // whether to gzip the backups
 	})
 	return probLogger
 }
-
 
 func main() {
 	buildDate = strings.Replace(buildDate, ".", " ", -1) // workaround for Make problems

--- a/cmd/dastard/dastard.go
+++ b/cmd/dastard/dastard.go
@@ -3,12 +3,14 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"path"
 	"strings"
 
 	"github.com/spf13/viper"
 	"github.com/usnistgov/dastard"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 var githash = "githash not computed"
@@ -16,12 +18,12 @@ var buildDate = "build date not computed"
 
 // makeFileExist checks that dir/filename exists, and creates the directory
 // and file if it doesn't.
-func makeFileExist(dir, filename string) error {
+func makeFileExist(dir, filename string) (string,  error) {
 	// Replace 1 instance of "$HOME" in the path with the actual home directory.
 	if strings.Contains(dir, "$HOME") {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return err
+			return "", err
 		}
 		dir = strings.Replace(dir, "$HOME", home, 1)
 	}
@@ -29,11 +31,11 @@ func makeFileExist(dir, filename string) error {
 	// Create directory <path>, if needed
 	if _, err := os.Stat(dir); err != nil {
 		if !os.IsNotExist(err) {
-			return err
+			return "", err
 		}
 		err2 := os.MkdirAll(dir, 0775)
 		if err2 != nil {
-			return err2
+			return "", err2
 		}
 	}
 
@@ -41,13 +43,13 @@ func makeFileExist(dir, filename string) error {
 	fullname := path.Join(dir, filename)
 	_, err := os.Stat(fullname)
 	if os.IsNotExist(err) {
-		f, err := os.OpenFile(fullname, os.O_WRONLY|os.O_CREATE, 0664)
-		if err != nil {
-			return err
+		f, err2 := os.OpenFile(fullname, os.O_WRONLY|os.O_CREATE, 0664)
+		if err2 != nil {
+			return "", err2
 		}
 		f.Close()
 	}
-	return nil
+	return fullname, nil
 }
 
 // setupViper sets up the viper configuration manager: says where to find config
@@ -58,7 +60,7 @@ func setupViper() error {
 	const path string = "$HOME/.dastard"
 	const filename string = "config"
 	const suffix string = ".yaml"
-	if err := makeFileExist(path, filename+suffix); err != nil {
+	if _, err := makeFileExist(path, filename+suffix); err != nil {
 		return err
 	}
 
@@ -70,17 +72,33 @@ func setupViper() error {
 	if err != nil {             // Handle errors reading the config file
 		return fmt.Errorf("error reading config file: %s", err)
 	}
-	fmt.Printf("Viper gets currenttime=%v\n", viper.Get("currenttime"))
 	return nil
 }
 
-var printVersion = flag.Bool("version", false, "print version and quit")
+func startProblemLogger(pfname string) *log.Logger {
+	probFile, err := os.OpenFile(pfname, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0666)
+	if err != nil {
+		msg := fmt.Sprintf("Could not open log file '%s'", pfname)
+		panic(msg)
+	}
+	probLogger := log.New(probFile, "", log.LstdFlags)
+	probLogger.SetOutput(&lumberjack.Logger{
+	    Filename:   pfname,
+	    MaxSize:    10,  // megabytes after which new file is created
+	    MaxBackups: 5,    // number of backups
+	    MaxAge:     365,  // days
+		Compress:   true, // whether to gzip the backups
+	})
+	return probLogger
+}
+
 
 func main() {
 	buildDate = strings.Replace(buildDate, ".", " ", -1) // workaround for Make problems
 	dastard.Build.Date = buildDate
 	dastard.Build.Githash = githash
 
+	printVersion := flag.Bool("version", false, "print version and quit")
 	flag.Parse()
 	if *printVersion {
 		fmt.Printf("This is DASTARD version %s\n", dastard.Build.Version)
@@ -89,12 +107,18 @@ func main() {
 		os.Exit(0)
 	}
 
+	// Start logging problems to a log file.
+	logname, err := makeFileExist("$HOME/.dastard/logs", "problems.log")
+	if err != nil {
+		panic(err)
+	}
+	dastard.ProblemLogger = startProblemLogger(logname)
+	fmt.Printf("Logging problems to %v\n", dastard.ProblemLogger)
+
 	// Find config file, creating it if needed, and read it.
 	if err := setupViper(); err != nil {
 		panic(err)
 	}
-
-	makeFileExist("$HOME/.dastard/logs", "problems.log")
 
 	abort := make(chan struct{})
 	go dastard.RunClientUpdater(dastard.Ports.Status, abort)

--- a/cmd/ringdump/ringdump.go
+++ b/cmd/ringdump/ringdump.go
@@ -2,27 +2,26 @@ package main
 
 import (
 	"bytes"
-    "flag"
-    "fmt"
-	"time"
+	"flag"
+	"fmt"
 	"github.com/usnistgov/dastard/packets"
 	"github.com/usnistgov/dastard/ringbuffer"
+	"time"
 )
 
 func dumpdata(data []byte, max int) {
 	reader := bytes.NewReader(data)
 	packet, _ := packets.ReadPacket(reader)
-	packstr := fmt.Sprintf("%v", packet)
-	fmt.Printf("Packet:\n%v...}\n", packstr[:400])
+	fmt.Println(packet.String())
 	fmt.Println("Data:")
 	if max > len(data) {
 		max = len(data)
 	}
-	if max % 16 > 0 {
+	if max%16 > 0 {
 		max -= max % 16
 	}
-	for i := 0; i<max; i+= 16 {
-		for j := i; j<i+16; j++ {
+	for i := 0; i < max; i += 16 {
+		for j := i; j < i+16; j++ {
 			fmt.Printf("%2.2x ", data[j])
 		}
 		fmt.Println()
@@ -45,7 +44,7 @@ func dump(cardnum int) error {
 	ps, _ := ring.PacketSize()
 	br := ring.BytesReadable()
 	bw := ring.BytesWriteable()
-	bs := 1+br+bw
+	bs := 1 + br + bw
 	fmt.Printf("Buffer has packet size %3d and %7d bytes are readable, %7d writeable, %7d total.\n", ps, br, bw, bs)
 	data1, err := ring.ReadMultipleOf(int(ps))
 	if err != nil {
@@ -57,7 +56,7 @@ func dump(cardnum int) error {
 	br = ring.BytesReadable()
 	bw = ring.BytesWriteable()
 	fmt.Printf("Buffer has packet size %3d and %7d bytes are readable, %7d writeable, %7d total.\n", ps, br, bw, bs)
-	time.Sleep(200*time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
 	br = ring.BytesReadable()
 	bw = ring.BytesWriteable()
 	fmt.Println("<sleep 200ms>")
@@ -72,13 +71,13 @@ func dump(cardnum int) error {
 }
 
 func main() {
-    cardnum := flag.Int("cardnum", 1, "Number of the ring buffer to open. 0-999 allowed")
-    flag.Usage = func() {
+	cardnum := flag.Int("cardnum", 1, "Number of the ring buffer to open. 0-999 allowed")
+	flag.Usage = func() {
 		fmt.Println("ringdump, a program to dump the Abaco data ring buffer status")
 		fmt.Println("Usage:")
 		flag.PrintDefaults()
 	}
- 	flag.Parse()
+	flag.Parse()
 	if *cardnum < 0 || *cardnum > 999 {
 		fmt.Println("Cardnum must be in the range [0, 999].")
 		return

--- a/cmd/ringdump/ringdump.go
+++ b/cmd/ringdump/ringdump.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+    "flag"
+    "fmt"
+	"time"
+	"github.com/usnistgov/dastard/packets"
+	"github.com/usnistgov/dastard/ringbuffer"
+)
+
+func dumpdata(data []byte, max int) {
+	reader := bytes.NewReader(data)
+	packet, _ := packets.ReadPacket(reader)
+	packstr := fmt.Sprintf("%v", packet)
+	fmt.Printf("Packet:\n%v...}\n", packstr[:400])
+	fmt.Println("Data:")
+	if max > len(data) {
+		max = len(data)
+	}
+	if max % 16 > 0 {
+		max -= max % 16
+	}
+	for i := 0; i<max; i+= 16 {
+		for j := i; j<i+16; j++ {
+			fmt.Printf("%2.2x ", data[j])
+		}
+		fmt.Println()
+	}
+}
+
+func dump(cardnum int) error {
+	ringname := fmt.Sprintf("xdma%d_c2h_0_buffer", cardnum)
+	ringdesc := fmt.Sprintf("xdma%d_c2h_0_description", cardnum)
+	fmt.Println("Dumping ring", ringname)
+	ring, err := ringbuffer.NewRingBuffer(ringname, ringdesc)
+	if err != nil {
+		return err
+	}
+	err = ring.Open()
+	if err != nil {
+		return err
+	}
+	defer ring.Close()
+	ps, _ := ring.PacketSize()
+	br := ring.BytesReadable()
+	bw := ring.BytesWriteable()
+	bs := 1+br+bw
+	fmt.Printf("Buffer has packet size %3d and %7d bytes are readable, %7d writeable, %7d total.\n", ps, br, bw, bs)
+	data1, err := ring.ReadMultipleOf(int(ps))
+	if err != nil {
+		return err
+	}
+
+	ring.DiscardStride(uint64(ps))
+	fmt.Println("<empty buffer>")
+	br = ring.BytesReadable()
+	bw = ring.BytesWriteable()
+	fmt.Printf("Buffer has packet size %3d and %7d bytes are readable, %7d writeable, %7d total.\n", ps, br, bw, bs)
+	time.Sleep(200*time.Millisecond)
+	br = ring.BytesReadable()
+	bw = ring.BytesWriteable()
+	fmt.Println("<sleep 200ms>")
+	fmt.Printf("Buffer has packet size %3d and %7d bytes are readable, %7d writeable, %7d total.\n", ps, br, bw, bs)
+	data2, err := ring.ReadMultipleOf(int(ps))
+	if err != nil {
+		return err
+	}
+	dumpdata(data1, int(ps))
+	dumpdata(data2, int(ps))
+	return nil
+}
+
+func main() {
+    cardnum := flag.Int("cardnum", 1, "Number of the ring buffer to open. 0-999 allowed")
+    flag.Usage = func() {
+		fmt.Println("ringdump, a program to dump the Abaco data ring buffer status")
+		fmt.Println("Usage:")
+		flag.PrintDefaults()
+	}
+ 	flag.Parse()
+	if *cardnum < 0 || *cardnum > 999 {
+		fmt.Println("Cardnum must be in the range [0, 999].")
+		return
+	}
+
+	err := dump(*cardnum)
+	if err != nil {
+		fmt.Println("dump returned error: ", err)
+	}
+}

--- a/data_source.go
+++ b/data_source.go
@@ -277,6 +277,7 @@ type AnySource struct {
 	sourceStateLock     sync.Mutex // guards sourceState
 	runDone             sync.WaitGroup
 	readCounter         int
+	problemLogger       *log.Logger
 }
 
 // SamplePeriod returns the sample period of the underlying source.

--- a/data_source.go
+++ b/data_source.go
@@ -277,7 +277,6 @@ type AnySource struct {
 	sourceStateLock     sync.Mutex // guards sourceState
 	runDone             sync.WaitGroup
 	readCounter         int
-	problemLogger       *log.Logger
 }
 
 // SamplePeriod returns the sample period of the underlying source.

--- a/global_config.go
+++ b/global_config.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"os"
 	"time"
-	)
+)
 
 // Portnumbers structs can contain all TCP port numbers used by Dastard.
 type Portnumbers struct {

--- a/global_config.go
+++ b/global_config.go
@@ -1,6 +1,10 @@
 package dastard
 
-import "time"
+import (
+	"log"
+	"os"
+	"time"
+	)
 
 // Portnumbers structs can contain all TCP port numbers used by Dastard.
 type Portnumbers struct {
@@ -39,7 +43,13 @@ var Build = BuildInfo{
 // DastardStartTime is a global holding the time init() was run
 var DastardStartTime time.Time
 
+// ProblemLogger will log warning messages to a file
+var ProblemLogger *log.Logger
+
 func init() {
 	setPortnumbers(5500)
 	DastardStartTime = time.Now()
+
+	// Dastard main program will override this, but at least initialize with a sensible value
+	ProblemLogger = log.New(os.Stderr, "", log.LstdFlags)
 }

--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,5 @@ require (
 	github.com/spf13/viper v1.6.3
 	github.com/zeromq/goczmq v0.0.0-20190906225145-a7546843a315
 	gonum.org/v1/gonum v0.7.0
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -165,6 +165,8 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/ini.v1 v1.51.0 h1:AQvPpx3LzTDM0AjnIRlVFwFFGC+npRopjZxLJj6gdno=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/lancero_source.go
+++ b/lancero_source.go
@@ -782,6 +782,7 @@ func (ls *LanceroSource) distributeData(buffersMsg BuffersChanType) *dataBlock {
 	if dataDropDetected {
 		droppedDuration := lastSampleTime.Sub(ls.previousLastSampleTime)
 		droppedFrames = roundint(droppedDuration.Seconds() * ls.sampleRate)
+		ProblemLogger.Printf("Dropped %d lancero frames over Δt=%v", droppedFrames, droppedDuration)
 	}
 
 	for channelIndex := 0; channelIndex < nchan; channelIndex++ {

--- a/lancero_source.go
+++ b/lancero_source.go
@@ -578,7 +578,7 @@ func (ls *LanceroSource) launchLanceroReader() {
 				var lastSampleTime time.Time
 				var dataDropDetected bool
 				if len(ls.active) > 1 {
-					panic("dropped data, handling multiple devices not yet implemented")
+					panic("Handling multiple devices not yet implemented")
 				}
 				dev := ls.active[0]
 				b, timeFix, err := dev.card.AvailableBuffer()

--- a/packets/packets.go
+++ b/packets/packets.go
@@ -21,9 +21,9 @@ type Packet struct {
 	packetLength   int
 
 	// Expected TLV objects. If 0 or 2+ examples, this cannot be processed
-	format *headPayloadFormat
-	shape  *headPayloadShape
-	offset headChannelOffset
+	format    *headPayloadFormat
+	shape     *headPayloadShape
+	offset    headChannelOffset
 	timestamp *PacketTimestamp
 
 	// Any other TLV objects.
@@ -74,11 +74,11 @@ func (p *Packet) ClearData() error {
 	return nil
 }
 
-// // String returns a string summarizing the packet's version, sequence number, and size.
-// func (p *Packet) String() string {
-// 	return fmt.Sprintf("Packet v0x%2.2x 0x%8.8x  Size (%2d+%5d)", p.version,
-// 		p.sequenceNumber, p.headerLength, p.payloadLength)
-// }
+// String returns a string summarizing the packet's version, sequence number, and size.
+func (p *Packet) String() string {
+	return fmt.Sprintf("Packet v0x%2.2x 0x%8.8x  Size (%2d+%5d)", p.version,
+		p.sequenceNumber, p.headerLength, p.payloadLength)
+}
 
 // Length returns the length of the entire packet, in bytes
 func (p *Packet) Length() int {
@@ -148,20 +148,20 @@ func (p *Packet) ResetTimestamp() error {
 // MakePretendPacket generates a copy of p with the given sequence number
 // and with the given value for the whole data payload.
 // Use it for making fake data to fill in where packets were dropped.
-func (p *Packet) MakePretendPacket(seqnum uint32, value int) (*Packet) {
+func (p *Packet) MakePretendPacket(seqnum uint32, value int) *Packet {
 	pretend := *p
 	pretend.sequenceNumber = seqnum
 	switch d := pretend.Data.(type) {
 	case []int16:
-		for i := range(d) {
+		for i := range d {
 			d[i] = int16(value)
 		}
 	case []int32:
-		for i := range(d) {
+		for i := range d {
 			d[i] = int32(value)
 		}
 	case []int64:
-		for i := range(d) {
+		for i := range d {
 			d[i] = int64(value)
 		}
 	}
@@ -259,7 +259,7 @@ func (p *Packet) Bytes() []byte {
 		exp = -11 // precise to 10 ps
 		period := math.Pow10(-int(exp)) / ts.Rate
 		denom = 1
-		for ;period > 65535; period *=0.5 {
+		for ; period > 65535; period *= 0.5 {
 			denom *= 2
 		}
 		num = uint16(math.Round(period))

--- a/packets/packets.go
+++ b/packets/packets.go
@@ -145,25 +145,31 @@ func (p *Packet) ResetTimestamp() error {
 	return nil
 }
 
-// MakePretendPacket generates a copy of p with the given sequence number
-// and with the given value for the whole data payload.
+// MakePretendPacket generates a copy of p with the given sequence number.
+// Each channel will repeat the first value in p.
 // Use it for making fake data to fill in where packets were dropped.
-func (p *Packet) MakePretendPacket(seqnum uint32, value int) *Packet {
+func (p *Packet) MakePretendPacket(seqnum uint32, nchan int) *Packet {
 	pretend := *p
 	pretend.sequenceNumber = seqnum
-	switch d := pretend.Data.(type) {
+	switch d := p.Data.(type) {
 	case []int16:
+		x := make([]int16, len(d))
 		for i := range d {
-			d[i] = int16(value)
+			x[i] = d[i % nchan]
 		}
+		pretend.Data = x
 	case []int32:
+		x := make([]int32, len(d))
 		for i := range d {
-			d[i] = int32(value)
+			x[i] = d[i % nchan]
 		}
+		pretend.Data = x
 	case []int64:
+		x := make([]int64, len(d))
 		for i := range d {
-			d[i] = int64(value)
+			x[i] = d[i % nchan]
 		}
+		pretend.Data = x
 	}
 	return &pretend
 }

--- a/packets/packets.go
+++ b/packets/packets.go
@@ -155,19 +155,19 @@ func (p *Packet) MakePretendPacket(seqnum uint32, nchan int) *Packet {
 	case []int16:
 		x := make([]int16, len(d))
 		for i := range d {
-			x[i] = d[i % nchan]
+			x[i] = d[i%nchan]
 		}
 		pretend.Data = x
 	case []int32:
 		x := make([]int32, len(d))
 		for i := range d {
-			x[i] = d[i % nchan]
+			x[i] = d[i%nchan]
 		}
 		pretend.Data = x
 	case []int64:
 		x := make([]int64, len(d))
 		for i := range d {
-			x[i] = d[i % nchan]
+			x[i] = d[i%nchan]
 		}
 		pretend.Data = x
 	}

--- a/packets/packets_test.go
+++ b/packets/packets_test.go
@@ -421,7 +421,7 @@ func TestFullPackets(t *testing.T) {
 		nsamp := pfake.Frames()
 		for i := 0; i < nsamp; i++ {
 			v := pfake.ReadValue(i)
-			want := 20*(i%8)
+			want := 20 * (i % 8)
 			if v != want {
 				t.Errorf("Packet.ReadValue(%d)=%d, want %d", i, v, want)
 			}
@@ -434,7 +434,7 @@ func TestFullPackets(t *testing.T) {
 		nsamp = p.Frames()
 		for i := 0; i < nsamp; i++ {
 			v := p.ReadValue(i)
-			want := 20*i
+			want := 20 * i
 			if v != want {
 				t.Errorf("Packet.ReadValue(%d)=%d, want %d", i, v, want)
 			}

--- a/packets/packets_test.go
+++ b/packets/packets_test.go
@@ -383,7 +383,7 @@ func TestFullPackets(t *testing.T) {
 	d32 := make([]int32, nd)
 	d64 := make([]int64, nd)
 	for i := 0; i < nd; i++ {
-		d16[i] = 2 * int16(i)
+		d16[i] = 20 * int16(i)
 		d32[i] = 20 * int32(i)
 		d64[i] = 20 * int64(i)
 	}
@@ -410,8 +410,7 @@ func TestFullPackets(t *testing.T) {
 
 		// Test PretendPacket
 		arbSeqNum := uint32(34567)
-		arbVal := 48
-		pfake := p.MakePretendPacket(arbSeqNum, arbVal)
+		pfake := p.MakePretendPacket(arbSeqNum, int(dims[0]))
 		if pfake == p {
 			t.Errorf("MakePretendPacket() result points to original packet")
 		}
@@ -422,13 +421,23 @@ func TestFullPackets(t *testing.T) {
 		nsamp := pfake.Frames()
 		for i := 0; i < nsamp; i++ {
 			v := pfake.ReadValue(i)
-			if v != arbVal {
-				t.Errorf("Packet.ReadValue(%d)=%d, want %d", i, v, arbVal)
+			want := 20*(i%8)
+			if v != want {
+				t.Errorf("Packet.ReadValue(%d)=%d, want %d", i, v, want)
 			}
 		}
 		v := pfake.ReadValue(-1)
 		if v != 0 {
 			t.Errorf("Packet.ReadValue(-1)=%d, want 0", v)
+		}
+		// Make sure we didn't clobber the original packet data
+		nsamp = p.Frames()
+		for i := 0; i < nsamp; i++ {
+			v := p.ReadValue(i)
+			want := 20*i
+			if v != want {
+				t.Errorf("Packet.ReadValue(%d)=%d, want %d", i, v, want)
+			}
 		}
 	}
 

--- a/packets/packets_test.go
+++ b/packets/packets_test.go
@@ -420,7 +420,7 @@ func TestFullPackets(t *testing.T) {
 				pfake.SequenceNumber(), arbSeqNum)
 		}
 		nsamp := pfake.Frames()
-		for i := 0; i<nsamp; i++ {
+		for i := 0; i < nsamp; i++ {
 			v := pfake.ReadValue(i)
 			if v != arbVal {
 				t.Errorf("Packet.ReadValue(%d)=%d, want %d", i, v, arbVal)

--- a/publish_data.go
+++ b/publish_data.go
@@ -391,7 +391,7 @@ func startSocket(port int, converter func(*DataRecord) [][]byte) (chan []*DataRe
 				message := converter(record)
 				err := pubSocket.SendMessage(message)
 				if err != nil {
-					fmt.Println("zmq send error publishing a triggered record:", err)
+					ProblemLogger.Println("zmq send error publishing a triggered record:", err)
 				}
 			}
 		}

--- a/publish_data.go
+++ b/publish_data.go
@@ -368,7 +368,7 @@ func configurePubSummariesSocket() error {
 // messages based on any records that appear on a new channel. Returns the
 // channel for other routines to fill. Close that channel to destroy the socket.
 //
-// *** This looks like it could be replaced by PubChanneler, but tests show terrible
+// *** This looks like it could be replaced by PubChanneler, but tests showed terrible
 // performance with Channeler ***
 func startSocket(port int, converter func(*DataRecord) [][]byte) (chan []*DataRecord, error) {
 	const publishChannelDepth = 500 // not totally sure how to choose this, but it should probably be
@@ -400,7 +400,7 @@ func startSocket(port int, converter func(*DataRecord) [][]byte) (chan []*DataRe
 }
 
 // rawTypeToBytes convert a []RawType to []byte using unsafe
-// see https://stackoverflow.com/questions/11924196/convert-between-slices-of-different-types?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa
+// see https://stackoverflow.com/questions/11924196/convert-between-slices-of-different-types
 func rawTypeToBytes(d []RawType) []byte {
 	header := *(*reflect.SliceHeader)(unsafe.Pointer(&d))
 	header.Cap *= 2 // byte takes up half the space of RawType
@@ -410,7 +410,6 @@ func rawTypeToBytes(d []RawType) []byte {
 }
 
 // rawTypeToUint16convert a []RawType to []uint16 using unsafe
-// see https://stackoverflow.com/questions/11924196/convert-between-slices-of-different-types?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa
 func rawTypeToUint16(d []RawType) []uint16 {
 	header := *(*reflect.SliceHeader)(unsafe.Pointer(&d))
 	data := *(*[]uint16)(unsafe.Pointer(&header))

--- a/ringbuffer/ringbuffer.go
+++ b/ringbuffer/ringbuffer.go
@@ -285,7 +285,7 @@ func (rb *RingBuffer) BytesReadable() int {
 // for a runt section with size less than stride bytes long
 func (rb *RingBuffer) DiscardStride(stride uint64) (err error) {
 	newRp := rb.desc.writePointer
-	if newRp % stride > 0 {
+	if newRp%stride > 0 {
 		newRp -= newRp % stride
 	}
 	rb.desc.readPointer = newRp

--- a/ringbuffer/ringbuffer_test.go
+++ b/ringbuffer/ringbuffer_test.go
@@ -156,9 +156,9 @@ func TestBufferWriteRead(t *testing.T) {
 
 	// Now put bytes in the buffer, use DiscardStride, and verify that the remaining size is what we expect.
 	writebuf.Write(deadbeef)
-	writes := 3  //  because we've written deadbeef 3 times now.
+	writes := 3 //  because we've written deadbeef 3 times now.
 	wantRump := 1000
-	b.DiscardStride(uint64(writes*expect-wantRump))
+	b.DiscardStride(uint64(writes*expect - wantRump))
 	data, err = b.Read(expect)
 	if err != nil {
 		t.Errorf("Failed to b.Read(%d) when nearly empty", expect)


### PR DESCRIPTION
Bahama now can drop a specified percentage of data packets. Dastard handles correctly, with logging to `~/.dastard/logs/problems.log` and log-rotation provided by the [lumberjack](https://github.com/natefinch/lumberjack) package.  Fixes #204.

Also ran `go fmt` for the first time in a while.