### PR TITLE
Channel numbering and indexing are separate concepts.

### DIFF
--- a/abaco.go
+++ b/abaco.go
@@ -547,6 +547,21 @@ func (as *AbacoSource) Sample() error {
 	sort.Sort(ByGroup(keys))
 	as.groupKeysSorted = keys
 
+	// Fill the channel names and numbers slices
+	as.chanNames = make([]string, 0, as.nchan)
+	as.chanNumbers = make([]int, 0, as.nchan)
+	as.rowColCodes = make([]RowColCode, 0, as.nchan)
+	ncol := len(keys)
+	for col, g := range as.groupKeysSorted {
+		for row := 0; row<g.nchan; row++ {
+			cnum := row + g.firstchan
+			name := fmt.Sprintf("chan%d", cnum)
+			as.chanNames = append(as.chanNames, name)
+			as.chanNumbers = append(as.chanNumbers, cnum)
+			as.rowColCodes = append(as.rowColCodes, rcCode(row, col, g.nchan, ncol))
+		}
+	}
+
 	// Each AbacoGroup should process its sampled packets.
 	for _, group := range as.groups {
 		group.samplePackets()

--- a/abaco.go
+++ b/abaco.go
@@ -404,6 +404,7 @@ func NewAbacoSource() (*AbacoSource, error) {
 	source.name = "Abaco"
 	source.arings = make(map[int]*AbacoRing)
 	source.groups = make(map[GroupIndex]*AbacoGroup)
+	source.channelsPerPixel = 1
 
 	deviceCodes, err := enumerateAbacoRings()
 	if err != nil {

--- a/data_source.go
+++ b/data_source.go
@@ -117,7 +117,6 @@ func Start(ds DataSource, queuedRequests chan func(), Npresamp int, Nsamples int
 	if err := ds.SetStateStarting(); err != nil {
 		return err
 	}
-
 	if err := ds.Sample(); err != nil {
 		ds.SetStateInactive()
 		return err
@@ -186,7 +185,7 @@ func (ds *AnySource) Stop() error {
 		return fmt.Errorf("AnySource not active, cannot stop")
 
 	case Starting:
-		log.Println("deleteme: called Stop on a Starting source; how to handle this??")
+		panic("Called Stop on a Starting source; how to handle this??")
 
 	case Active:
 		log.Println("AnySource.Stop() was called to stop an active source")
@@ -780,7 +779,7 @@ func (ds *AnySource) PrepareRun(Npresamples int, Nsamples int) error {
 		}
 		dsp.TriggerState = *ts
 
-		// Publish Records and Summaries over ZMQ. Not optional at this time.
+		// Publish Records and Record Summaries over ZMQ. Not optional at this time.
 		dsp.SetPubRecords()
 		dsp.SetPubSummaries()
 	}
@@ -868,7 +867,6 @@ type DataSegment struct {
 	voltsPerArb     float32
 	processed       bool
 	droppedFrames   int // normally zero, positive if dropped frames detected
-	// facts about the data source?
 }
 
 // NewDataSegment generates a pointer to a new, initialized DataSegment object.
@@ -918,6 +916,7 @@ func (stream *DataStream) AppendSegment(segment *DataSegment) {
 }
 
 // TrimKeepingN will trim (discard) all but the last N values in the DataStream.
+// N larger than the number of available values is NOT an error.
 // Returns the number of values in the stream after trimming (should be <= N).
 func (stream *DataStream) TrimKeepingN(N int) int {
 	L := len(stream.rawData)

--- a/data_source.go
+++ b/data_source.go
@@ -765,6 +765,7 @@ func (ds *AnySource) PrepareRun(Npresamples int, Nsamples int) error {
 	for channelIndex := range ds.processors {
 		dsp := NewDataStreamProcessor(channelIndex, ds.broker, Npresamples, Nsamples)
 		dsp.Name = ds.chanNames[channelIndex]
+		dsp.ChannelNumber = ds.chanNumbers[channelIndex]
 		dsp.SampleRate = ds.sampleRate
 		dsp.stream.voltsPerArb = vpa[channelIndex]
 		ds.processors[channelIndex] = dsp

--- a/lancero_source.go
+++ b/lancero_source.go
@@ -139,8 +139,8 @@ type LanceroDastardOutputJSON struct {
 // FiberMask must be identical across all cards, 0xFFFF uses all fibers, 0x0001 uses only fiber 0
 // ClockMhz must be identical arcross all cards, as of June 2018 it's always 125
 // CardDelay can have one value, which is shared across all cards, or must be one entry per card
-// ActiveCards is a slice of indicies into ls.devices to activate
-// AvailableCards is an output, contains a sorted slice of valid indicies for use in ActiveCards
+// ActiveCards is a slice of indices into ls.devices to activate
+// AvailableCards is an output, contains a sorted slice of valid indices for use in ActiveCards
 func (ls *LanceroSource) Configure(config *LanceroSourceConfig) (err error) {
 	ls.sourceStateLock.Lock()
 	defer ls.sourceStateLock.Unlock()

--- a/lancero_source.go
+++ b/lancero_source.go
@@ -422,6 +422,8 @@ type cringeGlobals struct {
 	BAD16CardDelay   int `json:"carddelay"`
 	XPT              int `json:"XPT"`
 	ClockMHz         int
+	// TODO. Someday Cringe will tell Dastard two more facts: the number of rows that exist
+	// (which might be more than the number read out) and the first row # being read out now.
 }
 
 // cringeGlobalsPath calculate the path to ~/.cringe/cringeGlobals.json by expanding the ~

--- a/lancero_source.go
+++ b/lancero_source.go
@@ -297,10 +297,11 @@ func (ls *LanceroSource) Sample() error {
 	ls.chanNames = make([]string, ls.nchan)
 	ls.chanNumbers = make([]int, ls.nchan)
 	for i := 1; i < ls.nchan; i += 2 {
-		ls.chanNames[i-1] = fmt.Sprintf("err%d", 1+i/2)
-		ls.chanNames[i] = fmt.Sprintf("chan%d", 1+i/2)
-		ls.chanNumbers[i-1] = 1 + i/2
-		ls.chanNumbers[i] = 1 + i/2
+		cnum := 1+i/2
+		ls.chanNames[i-1] = fmt.Sprintf("err%d", cnum)
+		ls.chanNames[i] = fmt.Sprintf("chan%d", cnum)
+		ls.chanNumbers[i-1] = cnum
+		ls.chanNumbers[i] = cnum
 	}
 
 	return nil

--- a/lancero_source.go
+++ b/lancero_source.go
@@ -70,6 +70,7 @@ func NewLanceroSource() (*LanceroSource, error) {
 	source.name = "Lancero"
 	source.nsamp = 1
 	source.devices = make(map[int]*LanceroDevice)
+	source.channelsPerPixel = 2
 
 	devnums, err := lancero.EnumerateLanceroDevices()
 	if err != nil {

--- a/process_data.go
+++ b/process_data.go
@@ -11,6 +11,7 @@ import (
 // DataStreamProcessor contains all the state needed to decimate, trigger, write, and publish data.
 type DataStreamProcessor struct {
 	channelIndex         int
+	ChannelNumber        int
 	Name                 string
 	Broker               *TriggerBroker
 	NSamples             int

--- a/rpc_server_test.go
+++ b/rpc_server_test.go
@@ -199,7 +199,7 @@ func TestServer(t *testing.T) {
 	if err1 := client.Call("SourceControl.ConfigureMixFraction", &mfo, &okay); err1 == nil {
 		t.Error("error on ConfigureMixFraction expected for non-mixable source")
 	}
-	tstate := FullTriggerState{ChannelIndicies: []int{0, 1, 2}}
+	tstate := FullTriggerState{ChannelIndices: []int{0, 1, 2}}
 	if err1 := client.Call("SourceControl.ConfigureTriggers", &tstate, &okay); err1 != nil {
 		t.Error("error on ConfigureTriggers:", err)
 	}

--- a/triggering.go
+++ b/triggering.go
@@ -61,7 +61,6 @@ type TriggerState struct {
 func (dsp *DataStreamProcessor) edgeMultiSetInitialState() {
 	dsp.edgeMultiInternalSearchState = initial
 	dsp.edgeMultiILastInspected = -math.MaxInt64 / 4
-	dsp.edgeMultiILastInspected = -math.MaxInt64 / 4
 	dsp.LastEdgeMultiTrigger = -math.MaxInt64 / 4
 	dsp.edgeMultiIPotential = -math.MaxInt64 / 4
 }
@@ -643,7 +642,7 @@ func (dsp *DataStreamProcessor) TriggerData() (records []*DataRecord, secondarie
 	return records, secondaries
 }
 
-// RecordSlice attaches the methods of sort.Interface to slices, sorting in increasing order.
+// RecordSlice attaches the methods of sort.Interface to slices of DataRecords, sorting in increasing order.
 type RecordSlice []*DataRecord
 
 func (p RecordSlice) Len() int           { return len(p) }


### PR DESCRIPTION
I've gone through objects `AnySource`, `DataSource`, `TriggerBroker` and `DataStreamProcessor` to make sure that nothing therein assumes that channels are numbered consecutively. Also removed the calculation of "channels per pixel" (which would have been broken by the non-consecutive numbering) and delegate that to the source, so that we generally get an answer of 1 except that `LanceroSource` has 2. Fixes #191.

Will still need to add features so Lancero sources can be non-consecutive (see #212), and fix Microscope to use real channel numbering (at present, it uses channel indices).