### PR TITLE
Handle TAG-type TLVs. Ignore TLVs types that aren't handled.

### DIFF
--- a/cmd/dastard/dastard.go
+++ b/cmd/dastard/dastard.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"runtime"
 	"strings"
 
 	"github.com/spf13/viper"
@@ -103,6 +104,7 @@ func main() {
 		fmt.Printf("This is DASTARD version %s\n", dastard.Build.Version)
 		fmt.Printf("Git commit hash: %s\n", githash)
 		fmt.Printf("Build time: %s\n", buildDate)
+		fmt.Printf("Running on %d CPUs.\n", runtime.NumCPU())
 		os.Exit(0)
 	}
 

--- a/packets/packets_test.go
+++ b/packets/packets_test.go
@@ -146,6 +146,15 @@ func chanOffsetToPacket(off headChannelOffset) []byte {
 	return buf.Bytes()
 }
 
+func nonsensePacket() []byte {
+	buf := new(bytes.Buffer)
+	binary.Write(buf, binary.BigEndian, byte(tlvINVALID))
+	binary.Write(buf, binary.BigEndian, byte(1))
+	binary.Write(buf, binary.BigEndian, uint16(0))
+	binary.Write(buf, binary.BigEndian, uint32(0))
+	return buf.Bytes()
+}
+
 func TestTLVs(t *testing.T) {
 	// Try a counter
 	c := HeadCounter{1234, 987654321}
@@ -218,6 +227,13 @@ func TestTLVs(t *testing.T) {
 	tp[2] = 66
 	if _, err = readTLV(bytes.NewReader(tp), 16); err == nil {
 		t.Errorf("readTLV() for PacketTimestamp succeeds with %d bits (>64), should fail", tp[2])
+	}
+
+	// Try a nonsensical TLV type. Should not be an error
+	nonsense := nonsensePacket()
+	_, err = readTLV(bytes.NewReader(nonsense), 8)
+	if err != nil {
+		t.Errorf("readTLV() for invalid TLV should be ignored, but returns %v", err)
 	}
 
 	// Try a channel offset


### PR DESCRIPTION
Fixes #217. Fixes #216.