### PR TITLE
Unwrap reset time

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -8,6 +8,7 @@
 * New agreement that Abaco will supply exactly [0, 2π) in the full range of whatever sized int data
   it generates. So if int32, use the highest 16 bits (issue 227).
 * Allow Abaco sources to change the time after which the phase unwrapping resets (issue 228).
+* Fix heartbeat ("ALIVE") message to have `Running=false` after sources stop (issue 232).
 
 **0.2.8** October 23, 2020
 * Remove idea of rows/columns from Dastard (used only in `LanceroSource`). Use chan groups otherwise (issue 214).

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -7,6 +7,7 @@
   replaced by artificial data, the latter might be larger). Send both in heartbeat ("ALIVE") message (issue 229).
 * New agreement that Abaco will supply exactly [0, 2π) in the full range of whatever sized int data
   it generates. So if int32, use the highest 16 bits (issue 227).
+* Allow Abaco sources to change the time after which the phase unwrapping resets (issue 228).
 
 **0.2.8** October 23, 2020
 * Remove idea of rows/columns from Dastard (used only in `LanceroSource`). Use chan groups otherwise (issue 214).

--- a/abaco.go
+++ b/abaco.go
@@ -411,8 +411,6 @@ func NewAbacoSource() (*AbacoSource, error) {
 	source.arings = make(map[int]*AbacoRing)
 	source.groups = make(map[GroupIndex]*AbacoGroup)
 	source.channelsPerPixel = 1
-	source.unwrapEnable = true
-	source.unwrapResetSamp = 20000
 
 	deviceCodes, err := enumerateAbacoRings()
 	if err != nil {

--- a/abaco.go
+++ b/abaco.go
@@ -397,8 +397,9 @@ type AbacoSource struct {
 
 	groups map[GroupIndex]*AbacoGroup
 
-	readPeriod      time.Duration
-	buffersChan     chan AbacoBuffersType
+	readPeriod  time.Duration
+	buffersChan chan AbacoBuffersType
+	// PhaseUnwrapper parameters must be stored for use when each AbacoGroup is created.
 	unwrapEnable    bool // whether to activate unwrapping
 	unwrapResetSamp int  // unwrap after this many samples (or never if ≤0)
 	AnySource

--- a/abaco_test.go
+++ b/abaco_test.go
@@ -145,7 +145,9 @@ func TestAbacoRing(t *testing.T) {
 	if len(ps) <= 0 {
 		t.Errorf("AbacoRing.samplePackets returned only %d packets", len(ps))
 	}
-	group := NewAbacoGroup(gIndex(ps[0]))
+	const enable = true
+	const resetAfter = 20000
+	group := NewAbacoGroup(gIndex(ps[0]), enable, resetAfter)
 	group.queue = append(group.queue, ps...)
 	err = group.samplePackets()
 	if err != nil {
@@ -269,7 +271,9 @@ func TestAbacoSource(t *testing.T) {
 func prepareDemux(nframes int) (*AbacoGroup, []*packets.Packet, [][]RawType) {
 	const offset = 1
 	const nchan = 16
-	group := NewAbacoGroup(GroupIndex{Firstchan: offset, Nchan: nchan})
+	const enable = true
+	const resetAfter = 20000
+	group := NewAbacoGroup(GroupIndex{Firstchan: offset, Nchan: nchan}, enable, resetAfter)
 	group.unwrap = group.unwrap[:0] // get rid of phase unwrapping
 
 	copies := make([][]RawType, nchan)

--- a/phase_unwrap.go
+++ b/phase_unwrap.go
@@ -1,5 +1,7 @@
 package dastard
 
+import "fmt"
+
 // PhaseUnwrapper makes phase values continous by adding integers as needed
 type PhaseUnwrapper struct {
 	lastVal       int16
@@ -32,8 +34,8 @@ func NewPhaseUnwrapper(fractionBits, lowBitsToDrop uint, enable bool, resetAfter
 	u.onePi = u.twoPi >> 1
 	u.resetAfter = resetAfter
 	u.enable = enable
-	if resetAfter <= 0 {
-		u.enable = false
+	if resetAfter <= 0 && enable {
+		panic(fmt.Sprintf("NewPhaseUnwrapper is enabled but with resetAfter=%d, expect positive", resetAfter))
 	}
 	return u
 }

--- a/phase_unwrap.go
+++ b/phase_unwrap.go
@@ -32,6 +32,9 @@ func NewPhaseUnwrapper(fractionBits, lowBitsToDrop uint, enable bool, resetAfter
 	u.onePi = u.twoPi >> 1
 	u.resetAfter = resetAfter
 	u.enable = enable
+	if resetAfter <= 0 {
+		u.enable = false
+	}
 	return u
 }
 

--- a/phase_unwrap_test.go
+++ b/phase_unwrap_test.go
@@ -33,7 +33,7 @@ func TestUnwrap(t *testing.T) {
 			}
 			pu.UnwrapInPlace(&data)
 
-			for i, want := range(original) {
+			for i, want := range original {
 				if enable {
 					want = 0
 				}
@@ -50,7 +50,7 @@ func TestUnwrap(t *testing.T) {
 				original[i] = data[i] >> bits2drop
 			}
 			pu.UnwrapInPlace(&data)
-			for i, want := range(original) {
+			for i, want := range original {
 				if enable {
 					want = RawType(i * (step >> bits2drop))
 				}

--- a/phase_unwrap_test.go
+++ b/phase_unwrap_test.go
@@ -4,9 +4,25 @@ import (
 	"testing"
 )
 
+func assertPanic(t *testing.T, f func()) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("The code did not panic")
+		}
+	}()
+	f()
+}
+
 func TestUnwrap(t *testing.T) {
 	const bits2drop = 2
 	enables := []bool{true, false}
+
+	shouldFail := func() {
+		NewPhaseUnwrapper(13, bits2drop, true, -1)
+	}
+	assertPanic(t, shouldFail)
+	NewPhaseUnwrapper(13, bits2drop, false, -1)
+	NewPhaseUnwrapper(13, bits2drop, true, 100)
 
 	for fractionbits := uint(13); fractionbits <= 16; fractionbits++ {
 		for _, enable := range enables {

--- a/phase_unwrap_test.go
+++ b/phase_unwrap_test.go
@@ -6,44 +6,61 @@ import (
 
 func TestUnwrap(t *testing.T) {
 	const bits2drop = 2
+	enables := []bool{true, false}
 
 	for fractionbits := uint(13); fractionbits <= 16; fractionbits++ {
-		pu := NewPhaseUnwrapper(fractionbits, bits2drop)
-		const ndata = 16
-		data := make([]RawType, ndata)
+		for _, enable := range enables {
+			const resetAfter = 20000
+			pu := NewPhaseUnwrapper(fractionbits, bits2drop, enable, resetAfter)
+			const ndata = 16
+			data := make([]RawType, ndata)
+			original := make([]RawType, ndata)
 
-		// Test unwrap when no change is expected
-		pu.UnwrapInPlace(&data)
-		for i := 0; i < ndata; i++ {
-			if data[i] != 0 {
-				t.Errorf("data[%d] = %d, want 0", i, data[i])
+			// Test unwrap when no change is expected
+			pu.UnwrapInPlace(&data)
+			for i := 0; i < ndata; i++ {
+				if data[i] != 0 {
+					t.Errorf("data[%d] = %d, want 0", i, data[i])
+				}
 			}
-		}
-		// Test basic unwrap
-		data[8] = RawType(1) << fractionbits // this is a jump of 2π
-		data[9] = data[8]
-		pu.UnwrapInPlace(&data)
-		for i := 0; i < ndata; i++ {
-			if data[i] != 0 {
-				t.Errorf("data[%d] = %d, want 0", i, data[i])
+			// Test basic unwrap
+			data[6] = RawType(1) << fractionbits // this is a jump of 2π
+			data[7] = data[6]
+			data[8] = data[7]
+			data[9] = data[8]
+			for i := 0; i < ndata; i++ {
+				original[i] = data[i] >> bits2drop
 			}
-		}
-		// Test unwrap on sawtooth of 4 steps
-		// Result should be a line.
-		step := 1 << (fractionbits - 2)
-		mod := step * 4
-		for i := 0; i < ndata; i++ {
-			data[i] = RawType((i * step) % mod)
-		}
-		pu.UnwrapInPlace(&data)
-		for i := 0; i < ndata; i++ {
-			want := RawType(i * (step >> bits2drop))
-			if data[i] != want {
-				t.Errorf("(%d,%d) data[%d] = %d, want %d", fractionbits, bits2drop, i, data[i], want)
+			pu.UnwrapInPlace(&data)
+
+			for i, want := range(original) {
+				if enable {
+					want = 0
+				}
+				if data[i] != want {
+					t.Errorf("unwrap: %t, data[%d] = %d, want %d", enable, i, data[i], want)
+				}
+			}
+			// Test unwrap on sawtooth of 4 steps
+			// Result should be a line.
+			step := 1 << (fractionbits - 2)
+			mod := step * 4
+			for i := 0; i < ndata; i++ {
+				data[i] = RawType((i * step) % mod)
+				original[i] = data[i] >> bits2drop
+			}
+			pu.UnwrapInPlace(&data)
+			for i, want := range(original) {
+				if enable {
+					want = RawType(i * (step >> bits2drop))
+				}
+				if data[i] != want {
+					t.Errorf("unwrap: %t, (%d,%d) data[%d] = %d, want %d", enable, fractionbits,
+						bits2drop, i, data[i], want)
+				}
 			}
 		}
 	}
-
 }
 
 func BenchmarkPhaseUnwrap(b *testing.B) {
@@ -55,7 +72,9 @@ func BenchmarkPhaseUnwrap(b *testing.B) {
 
 	const bits2drop = 2
 	for fractionbits := uint(13); fractionbits <= 16; fractionbits++ {
-		pu := NewPhaseUnwrapper(fractionbits, bits2drop)
+		const enable = true
+		const resetAfter = 20000
+		pu := NewPhaseUnwrapper(fractionbits, bits2drop, enable, resetAfter)
 		for i := 0; i < b.N; i++ {
 			pu.UnwrapInPlace(&data)
 		}

--- a/roach.go
+++ b/roach.go
@@ -110,7 +110,9 @@ func (dev *RoachDevice) samplePacket() error {
 	dev.nchan = int(header.Nchan)
 	dev.unwrap = make([]*PhaseUnwrapper, dev.nchan)
 	for i := range dev.unwrap {
-		dev.unwrap[i] = NewPhaseUnwrapper(roachFractionBits, roachBitsToDrop)
+		const enable = true
+		const resetAfter = 20000
+		dev.unwrap[i] = NewPhaseUnwrapper(roachFractionBits, roachBitsToDrop, enable, resetAfter)
 	}
 	return err
 }

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -353,6 +353,8 @@ func (s *SourceControl) handlePossibleStoppedSource() {
 		s.status.Running = false
 		s.isSourceActive = false
 		s.clientUpdates <- ClientUpdate{"STATUS", s.status}
+		s.heartbeats <- Heartbeat{Running: false}
+
 		if s.ActiveSource.ShouldAutoRestart() {
 			log.Println("dastard is aware it should AutoRestart, but it's not implemented yet")
 		}

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -666,11 +666,15 @@ func RunRPCServer(portrpc int, block bool) {
 		// That is, we are intentionally NOT checking any error returned by ConfigureLanceroSource.
 	}
 	var asc AbacoSourceConfig
+	// Set reasonable defaults when not in the config file.
+	asc.Unwrapping = true
+	asc.UnwrapResetSamp = 20000
 	err = viper.UnmarshalKey("abaco", &asc)
 	if err == nil {
 		_ = sourceControl.ConfigureAbacoSource(&asc, &okay)
 		// intentionally not checking for configure errors since it might fail on non abaco systems
 	}
+
 	var rsc RoachSourceConfig
 	err = viper.UnmarshalKey("roach", &rsc)
 	if err == nil {


### PR DESCRIPTION
* Allow the `PhaseUnwrapper` unwrap reset time to be set by an RPC command when the Abaco source is started.
* Fix bug where the ALIVE message said Running=true after source was stopped.
Fixes #228. Fixes #232.