### PR TITLE
Fixconfigcrash

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,6 +1,9 @@
 ## DASTARD Versions
 
-**0.2.12** March 2022
+**0.2.13** May 2022-
+* Fix crashing problem when you start with Edge Multi Triggers on (issue 271).
+
+**0.2.12** March 18, 2022
 * Add `doc/` directory with `DASTARD.md` to explain the internal design of the code (issue 261).
 * Make Lancero driver's ring buffer be 256 MB instead of 32 MB (issue 258).
 * Redesign triggering so all-channel sync point is explicit (not hidden in `TriggerBroker`) (issues 235, 255).

--- a/abaco_test.go
+++ b/abaco_test.go
@@ -78,7 +78,7 @@ func TestGeneratePackets(t *testing.T) {
 	}
 }
 
-func _skip_TestAbacoRing(t *testing.T) {
+func TestAbacoRing(t *testing.T) {
 	if _, err := NewAbacoRing(99999); err == nil {
 		t.Errorf("NewAbacoRing(99999) succeeded, want failure")
 	}

--- a/abaco_test.go
+++ b/abaco_test.go
@@ -166,7 +166,7 @@ func _skip_TestAbacoRing(t *testing.T) {
 	}
 }
 
-func TestAbacoUDP(t *testing.T) {
+func _skip_TestAbacoUDP(t *testing.T) {
 	if _, err := NewAbacoUDPReceiver("nonexistenthost.remote.internet:4999"); err == nil {
 		t.Errorf("NewAbacoUDPReceiver(\"nonexistenthost.remote.internet:4999\") succeeded, want failure")
 	}

--- a/abaco_test.go
+++ b/abaco_test.go
@@ -166,7 +166,7 @@ func TestAbacoRing(t *testing.T) {
 	}
 }
 
-func _skip_TestAbacoUDP(t *testing.T) {
+func TestAbacoUDP(t *testing.T) {
 	if _, err := NewAbacoUDPReceiver("nonexistenthost.remote.internet:4999"); err == nil {
 		t.Errorf("NewAbacoUDPReceiver(\"nonexistenthost.remote.internet:4999\") succeeded, want failure")
 	}
@@ -189,7 +189,7 @@ func _skip_TestAbacoUDP(t *testing.T) {
 	}
 }
 
-func _skip_TestAbacoSource(t *testing.T) {
+func TestAbacoSource(t *testing.T) {
 	source, err := NewAbacoSource()
 	if err != nil {
 		t.Fatalf("NewAbacoSource() fails: %s", err)
@@ -346,7 +346,7 @@ func prepareDemux(nframes int) (*AbacoGroup, []*packets.Packet, [][]RawType) {
 	return group, allpackets, copies
 }
 
-func _skip_TestDemux(t *testing.T) {
+func TestDemux(t *testing.T) {
 	const nframes = 32768
 	group, allpackets, copies := prepareDemux(nframes)
 	want := (nframes * len(copies)) / 4096

--- a/data_source.go
+++ b/data_source.go
@@ -825,6 +825,12 @@ func (ds *AnySource) PrepareRun(Npresamples int, Nsamples int) error {
 		for _, channelIndex := range ts.ChannelIndices {
 			if channelIndex < ds.nchan {
 				tsptrs[channelIndex] = &(fts[i].TriggerState)
+				tsptrs[channelIndex].EdgeMulti = false // fix for issue #271
+				// won't be neccesary if we get rid of the old EMT fields used for rpc compatability
+				// basically EMTState is not saved, so it has threshold = 0
+				// so if we come back with EdgeMulti=true
+				// then we trigger on every sample, and it crashes
+				// should we even load trigger states at all?
 			}
 		}
 	}

--- a/global_config.go
+++ b/global_config.go
@@ -35,7 +35,7 @@ type BuildInfo struct {
 
 // Build is a global holding compile-time information about the build
 var Build = BuildInfo{
-	Version: "0.2.12",
+	Version: "0.2.13",
 	Githash: "no git hash computed",
 	Date:    "no build date computed",
 }

--- a/roach_test.go
+++ b/roach_test.go
@@ -73,7 +73,7 @@ func publishRoachPackets(port int, nchan uint16, value uint16) (closer chan stru
 }
 
 // TestDevice checks that the raw RoachDevice can receive and parse a header
-func _skip_TestRoachDevice(t *testing.T) {
+func TestRoachDevice(t *testing.T) {
 	// Start generating Roach packets, until closer is closed.
 	port := 60001
 	var nchan uint16 = 40
@@ -124,7 +124,7 @@ func _skip_TestRoachDevice(t *testing.T) {
 }
 
 // TestDevice checks that the full RoachSource can receive and parse a header
-func _skip_TestRoachSource(t *testing.T) {
+func TestRoachSource(t *testing.T) {
 	// Start generating Roach packets, until closer is closed.
 	port := 60005
 	var nchan uint16 = 40


### PR DESCRIPTION
fixes a crash when EdgeMulti is saved as true but the EMT state is not saved

also fixes some EMT crashes