### PR TITLE
handle trimming in only one spot, also always use stream.x instead of…

### DIFF
--- a/edge_multi_trigger.go
+++ b/edge_multi_trigger.go
@@ -360,7 +360,7 @@ func (dsp *DataStreamProcessor) edgeMultiTriggerComputeAppend(records []*DataRec
 	// fmt.Println("firstFrameIndex", stream.firstFrameIndex, "len(segment.rawData)", len(stream.rawData))
 	recordSpecs := dsp.EMTState.edgeMultiComputeRecordSpecs(stream.rawData, stream.firstFrameIndex)
 	for _, recordSpec := range recordSpecs {
-		record := dsp.triggerAtSpecificSamples(&stream, int(recordSpec.firstRisingFrameIndex-stream.firstFrameIndex), int(recordSpec.npre), int(recordSpec.nsamp))
+		record := dsp.triggerAtSpecificSamples(int(recordSpec.firstRisingFrameIndex-stream.firstFrameIndex), int(recordSpec.npre), int(recordSpec.nsamp))
 		records = append(records, record)
 	}
 	// n_before := len(stream.rawData)

--- a/edge_multi_trigger.go
+++ b/edge_multi_trigger.go
@@ -320,9 +320,6 @@ func (s *EMTState) edgeMultiComputeRecordSpecs(raw []RawType, frameIndexOfraw0 F
 		t, u, v = u, v, FrameIndex(x.triggerInd)+frameIndexOfraw0
 		recordSpec, valid := edgeMultiShouldRecord(t, u, v, s.npre, s.nsamp, s.mode)
 		if valid {
-			// if (recordSpec.firstRisingFrameIndex - frameIndexOfraw0) < FrameIndex(s.npre) {
-			// 	panic("wtf")
-			// }
 			recordSpecs = append(recordSpecs, recordSpec)
 		}
 	}
@@ -342,9 +339,6 @@ func (s *EMTState) edgeMultiComputeRecordSpecs(raw []RawType, frameIndexOfraw0 F
 		// is at least 1 nsamp from there, we know we can write a full length record
 		recordSpec, valid := edgeMultiShouldRecord(u, v, nextFrameIndexToInspect, s.npre, s.nsamp, s.mode)
 		if valid {
-			// if (recordSpec.firstRisingFrameIndex - frameIndexOfraw0) < FrameIndex(s.npre) {
-			// 	panic("wtf")
-			// }
 			recordSpecs = append(recordSpecs, recordSpec)
 		}
 		u = v // we signal that this has already been recordized by setting u = v

--- a/process_data.go
+++ b/process_data.go
@@ -278,12 +278,12 @@ func (dsp *DataStreamProcessor) AnalyzeData(records []*DataRecord) {
 	}
 }
 
-// TrimStream trims a DataStreamProcessor's stream to contain only one record's worth of old
-// samples. That should more than suffice to extract triggers from future data.
+// TrimStream trims a DataStreamProcessor's stream to contain a limited amount of data.
+// When zero threshold model is enabled, we can always look back at least 4 samples,
+// so I (GCO) think the minimum we can keep is ds.NSamples+4. I added more since it doesn't
+// cost much and the details of kink model could be change in the future.
 func (dsp *DataStreamProcessor) TrimStream() {
-	// Leave one full possible trigger in the stream, because trigger algorithms
-	// should not inspect the last NSamples samples
-	dsp.stream.TrimKeepingN(dsp.NSamples)
+	dsp.stream.TrimKeepingN(dsp.NToKeepOnTrim())
 }
 
 // return the uncorrected std deviation of a float slice

--- a/process_data.go
+++ b/process_data.go
@@ -286,7 +286,7 @@ func (dsp *DataStreamProcessor) TrimStream() {
 	dsp.stream.TrimKeepingN(dsp.NToKeepOnTrim())
 }
 
-// return the uncorrected std deviation of a float slice
+// stdDev returns the std deviation of a float slice
 func stdDev(a []float64) float64 {
 	if len(a) == 0 {
 		return math.NaN()

--- a/process_data.go
+++ b/process_data.go
@@ -223,7 +223,8 @@ func (dsp *DataStreamProcessor) AnalyzeData(records []*DataRecord) {
 
 		var val float64        // used to calculate pretrigger mean, then reused in the next loop
 		var valPTDelta float64 // used to calculate pretrigger delta
-		// slope = dot(x,y.-y[0])/z where z = dot(x,x) and x = [0, 1, 2, ..., N-1]/(N-1), where .-y[0] is elementwise subtraction of the first element
+		// slope = dot(x,y.-y[0])/z where z = dot(x,x) and x = [0, 1, 2, ..., N-1]/(N-1),
+		// where .-y[0] is elementwise subtraction of the first element
 		npre := rec.presamples
 		d0 := dataVec.AtVec(0)
 		xmean := float64(npre-1) * 0.5
@@ -279,9 +280,8 @@ func (dsp *DataStreamProcessor) AnalyzeData(records []*DataRecord) {
 }
 
 // TrimStream trims a DataStreamProcessor's stream to contain a limited amount of data.
-// When zero threshold model is enabled, we can always look back at least 4 samples,
-// so I (GCO) think the minimum we can keep is ds.NSamples+4. I added more since it doesn't
-// cost much and the details of kink model could be change in the future.
+// When the zero-threshold model is enabled, we might look back at least 4 samples,
+// but the EMTState.NToKeepOnTrim() method figures out the necessary number.
 func (dsp *DataStreamProcessor) TrimStream() {
 	dsp.stream.TrimKeepingN(dsp.NToKeepOnTrim())
 }

--- a/triggering.go
+++ b/triggering.go
@@ -35,15 +35,16 @@ type TriggerState struct {
 }
 
 // create a record using dsp.NPresamples and dsp.NSamples
-func (dsp *DataStreamProcessor) triggerAt(stream *DataStream, i int) *DataRecord {
-	record := dsp.triggerAtSpecificSamples(stream, i, dsp.NPresamples, dsp.NSamples)
-	return record
+func (dsp *DataStreamProcessor) triggerAt(i int) *DataRecord {
+	return dsp.triggerAtSpecificSamples(i, dsp.NPresamples, dsp.NSamples)
 }
 
 // create a record with NPresamples and NSamples passed as arguments
-func (dsp *DataStreamProcessor) triggerAtSpecificSamples(stream *DataStream, i int, NPresamples int, NSamples int) *DataRecord {
+func (dsp *DataStreamProcessor) triggerAtSpecificSamples(i int, NPresamples int, NSamples int) *DataRecord {
+
 	data := make([]RawType, NSamples)
 	// fmt.Printf("triggerAtSpecificSamples i %v, NPresamples %v, NSamples %v, len(rawData) %v\n", i, NPresamples, NSamples, len(segment.rawData))
+	stream := dsp.stream
 	copy(data, stream.rawData[i-NPresamples:i+NSamples-NPresamples])
 	tf := stream.firstFrameIndex + FrameIndex(i)
 	tt := stream.TimeOf(i)
@@ -59,14 +60,13 @@ func (dsp *DataStreamProcessor) edgeTriggerComputeAppend(records []*DataRecord) 
 	if !dsp.EdgeTrigger {
 		return records
 	}
-	stream := dsp.stream
-	raw := stream.rawData
+	raw := dsp.stream.rawData
 	ndata := len(raw)
 
 	// Solve the problem of signed data by shifting all values up by 2^15
 	if dsp.stream.signed {
 		raw = make([]RawType, ndata)
-		copy(raw, stream.rawData)
+		copy(raw, dsp.stream.rawData)
 		for i := 0; i < ndata; i++ {
 			raw[i] += 32768
 		}
@@ -76,7 +76,7 @@ func (dsp *DataStreamProcessor) edgeTriggerComputeAppend(records []*DataRecord) 
 		diff := int32(raw[i]) + int32(raw[i-1]) - int32(raw[i-2]) - int32(raw[i-3])
 		if (dsp.EdgeRising && diff >= dsp.EdgeLevel) ||
 			(dsp.EdgeFalling && diff <= -dsp.EdgeLevel) {
-			newRecord := dsp.triggerAt(&stream, i)
+			newRecord := dsp.triggerAt(i)
 			records = append(records, newRecord)
 			i += dsp.NSamples
 		}
@@ -88,8 +88,7 @@ func (dsp *DataStreamProcessor) levelTriggerComputeAppend(records []*DataRecord)
 	if !dsp.LevelTrigger {
 		return records
 	}
-	stream := dsp.stream
-	raw := stream.rawData
+	raw := dsp.stream.rawData
 	ndata := len(raw)
 	nsamp := FrameIndex(dsp.NSamples)
 
@@ -97,7 +96,7 @@ func (dsp *DataStreamProcessor) levelTriggerComputeAppend(records []*DataRecord)
 	nFoundTrigs := len(records)
 	nextFoundTrig := FrameIndex(math.MaxInt64)
 	if nFoundTrigs > 0 {
-		nextFoundTrig = records[idxNextTrig].trigFrame - stream.firstFrameIndex
+		nextFoundTrig = records[idxNextTrig].trigFrame - dsp.stream.firstFrameIndex
 	}
 
 	// Solve the problem of signed data by shifting all values up by 2^15
@@ -105,7 +104,7 @@ func (dsp *DataStreamProcessor) levelTriggerComputeAppend(records []*DataRecord)
 	if dsp.stream.signed {
 		threshold += 32768
 		raw = make([]RawType, ndata)
-		copy(raw, stream.rawData)
+		copy(raw, dsp.stream.rawData)
 		for i := 0; i < ndata; i++ {
 			raw[i] += 32768
 		}
@@ -121,7 +120,7 @@ func (dsp *DataStreamProcessor) levelTriggerComputeAppend(records []*DataRecord)
 			i = int(nextFoundTrig) + dsp.NSamples - 1
 			idxNextTrig++
 			if nFoundTrigs > idxNextTrig {
-				nextFoundTrig = records[idxNextTrig].trigFrame - stream.firstFrameIndex
+				nextFoundTrig = records[idxNextTrig].trigFrame - dsp.stream.firstFrameIndex
 			} else {
 				nextFoundTrig = math.MaxInt64
 			}
@@ -131,7 +130,7 @@ func (dsp *DataStreamProcessor) levelTriggerComputeAppend(records []*DataRecord)
 		// If you get here, a level trigger is permissible. Check for it.
 		if (dsp.LevelRising && raw[i] >= threshold && raw[i-1] < threshold) ||
 			(!dsp.LevelRising && raw[i] <= threshold && raw[i-1] > threshold) {
-			newRecord := dsp.triggerAt(&stream, i)
+			newRecord := dsp.triggerAt(i)
 			records = append(records, newRecord)
 		}
 	}
@@ -170,7 +169,7 @@ func (dsp *DataStreamProcessor) autoTriggerComputeAppend(records []*DataRecord) 
 	for nextPotentialTrig+nsamp-npre < FrameIndex(ndata) {
 		if nextPotentialTrig+nsamp <= nextFoundTrig {
 			// auto trigger is allowed: no conflict with previously found non-auto triggers
-			newRecord := dsp.triggerAt(&stream, int(nextPotentialTrig))
+			newRecord := dsp.triggerAt(int(nextPotentialTrig))
 			records = append(records, newRecord)
 			nextPotentialTrig += delaySamples
 
@@ -253,7 +252,7 @@ func (dsp *DataStreamProcessor) TriggerData() (records []*DataRecord) {
 func (dsp *DataStreamProcessor) TriggerDataSecondary(secondaryTrigList []FrameIndex) (secRecords []*DataRecord) {
 	stream := dsp.stream
 	for _, st := range secondaryTrigList {
-		secRecords = append(secRecords, dsp.triggerAt(&stream, int(st-stream.firstFrameIndex)))
+		secRecords = append(secRecords, dsp.triggerAt(int(st-stream.firstFrameIndex)))
 	}
 	return secRecords
 }

--- a/triggering.go
+++ b/triggering.go
@@ -28,9 +28,9 @@ type TriggerState struct {
 	EdgeRising  bool
 	EdgeFalling bool
 	EdgeLevel   int32
+	EdgeMulti   bool // enable EdgeMulti (actually used in triggering)
 
-	EdgeMulti                      bool // enable EdgeMulti (actually used in triggering)
-	EMTBackwardCompatibleRPCFields      // used to allow the old RPC messages to still work
+	EMTBackwardCompatibleRPCFields // used to allow the old RPC messages to still work
 	EMTState
 }
 
@@ -43,7 +43,6 @@ func (dsp *DataStreamProcessor) triggerAt(i int) *DataRecord {
 func (dsp *DataStreamProcessor) triggerAtSpecificSamples(i int, NPresamples int, NSamples int) *DataRecord {
 
 	data := make([]RawType, NSamples)
-	// fmt.Printf("triggerAtSpecificSamples i %v, NPresamples %v, NSamples %v, len(rawData) %v\n", i, NPresamples, NSamples, len(segment.rawData))
 	stream := dsp.stream
 	copy(data, stream.rawData[i-NPresamples:i+NSamples-NPresamples])
 	tf := stream.firstFrameIndex + FrameIndex(i)
@@ -194,7 +193,6 @@ func (dsp *DataStreamProcessor) autoTriggerComputeAppend(records []*DataRecord) 
 // a triggerList object just when the triggers happened.
 func (dsp *DataStreamProcessor) TriggerData() (records []*DataRecord) {
 	if dsp.EdgeMulti {
-		// EdgeMulti does not play nice with other triggers!!
 		records = dsp.edgeMultiTriggerComputeAppend(records)
 		trigList := triggerList{channelIndex: dsp.channelIndex}
 		trigList.frames = make([]FrameIndex, len(records))
@@ -208,6 +206,7 @@ func (dsp *DataStreamProcessor) TriggerData() (records []*DataRecord) {
 			FrameIndex(len(dsp.stream.rawData)) - FrameIndex(dsp.NSamples-dsp.NPresamples)
 
 		dsp.lastTrigList = trigList
+		// EdgeMulti does not play nice with other triggers, so return now!!
 		return records
 	}
 


### PR DESCRIPTION
1. call `DataStream.TrimStream` in only one location, with correct value
2. prefer `stream.x` over `stream.segment.x` or `segment=stream.segment;segment.x` for clairity