### PR TITLE
Packet dumper, a new program

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Dastard
 [![Build Status](https://app.travis-ci.com/usnistgov/dastard.svg?branch=master)](https://app.travis-ci.com/github/usnistgov/dastard)
 
-A data acquisition framework for NIST transition-edge sensor (TES) microcalorimeters. Designed to replace the earlier programs `ndfb_server` and `matter` (see their [bitbucket repository](https://bitbucket.org/nist_microcal/nasa_daq)).
+A data acquisition program for NIST transition-edge sensor (TES) microcalorimeters. Designed to replace the earlier programs `ndfb_server` and `matter` (see their [bitbucket repository](https://bitbucket.org/nist_microcal/nasa_daq)).
 
 ## Installation
-Requires Go version 1.16 or higher because [gonum](http://gonum.org/v1/gonum/mat) requires it. Dastard is tested automatically on versions 1.16 and LATEST (as of May 2022, Go version 1.18.2 is the most recent).
+**Requires Go version 1.16)) (released February 2021) or higher because [gonum](http://gonum.org/v1/gonum/mat) requires it. Dastard is tested automatically on versions 1.16 and LATEST (as of September 2022, Go version 1.19.1 is the most recent).
 
-We recommend always using the `Makefile` to build Dastard. That's not a typical go usage, but we have a very simple trick built into the `Makefile` that allows it to call `go build` with linker arguments that override the default values of two global variables. By this step, we are able to get the git hash and the build date of the current version to be known inside Dastard. Hooray! The lesson is always use one of the following:
+We recommend always using the `Makefile` to build Dastard. That's not a typical go usage, but we have a very simple trick built into the `Makefile` that allows it to execute `go build` with linker arguments that override the default values of two global variables. By this step, we are able to get the git hash and the build date of the current version to be known inside Dastard. Hooray! The lesson is always use one of the following:
 ```
 # To build locally and run that copy
 make build && ./dastard
@@ -42,7 +42,7 @@ cd dastard
 # Build, then try to run the local copy
 # Using the Makefile is preferred, because it's the only way we're aware of to get the git hash and build date
 # embedded in the built binary file.
-# 
+#
 make build && ./dastard --version
 
 # Check whether the GOPATH is in your bash path. If not, update ~/.bashrc to make it so.
@@ -66,17 +66,16 @@ sudo apt-get -y update
 sudo apt-get install -y libsodium-dev libczmq-dev git
 ```
 
-### MacOS dependencies
+### MacOS dependencies (Homebrew or MacPorts)
 
-#### Homebrew
-`brew install go pkg-config czmq libsodium`
-
-#### Macports
-`port install go czmq libsodium-dev pkg-config`
-
+As appropriate, use one of
+```brew install go pkg-config czmq libsodium```
+or
+```sudo port install go czmq libsodium-dev pkg-config```
 
 
-### Also install these
+
+### Also install these companion programs
 
 * Install microscope https://github.com/usnistgov/microscope
 * Install dastard_commander https://github.com/usnistgov/dastardcommander
@@ -90,7 +89,7 @@ This only applies to users who will need µMUX, or any data source that eventual
 sudo sysctl -w net.core.rmem_max=67108864
 ```
 
-If that works as intended, you can make the configuration permanent (i.e., it will persist after rebooting) if 
+If that works as intended, you can make the configuration permanent (i.e., it will persist after rebooting) if
 you add the following line to `/etc/sysctl.conf`
 
 `net.core.rmem_max=67108864`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 A data acquisition program for NIST transition-edge sensor (TES) microcalorimeters. Designed to replace the earlier programs `ndfb_server` and `matter` (see their [bitbucket repository](https://bitbucket.org/nist_microcal/nasa_daq)).
 
 ## Installation
-**Requires Go version 1.16)) (released February 2021) or higher because [gonum](http://gonum.org/v1/gonum/mat) requires it. Dastard is tested automatically on versions 1.16 and LATEST (as of September 2022, Go version 1.19.1 is the most recent).
+**Requires Go version 1.16** (released February 2021) or higher because [gonum](http://gonum.org/v1/gonum/mat) requires it. Dastard is tested automatically on versions 1.16 and LATEST (as of September 2022, Go version 1.19.1 is the most recent).
 
 We recommend always using the `Makefile` to build Dastard. That's not a typical go usage, but we have a very simple trick built into the `Makefile` that allows it to execute `go build` with linker arguments that override the default values of two global variables. By this step, we are able to get the git hash and the build date of the current version to be known inside Dastard. Hooray! The lesson is always use one of the following:
 ```

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 ## DASTARD Versions
 
+**0.2.15** September 2022-
+* Add a `udpdump` main program to read a few packets from an Abaco UDP source (issue 290).
+
 **0.2.14** September 26, 2022
 * Add features to test use of multiple Abaco cards at once (like Tomcat-1k).
 * Fix crashes found when data rates (in sim data) are very low and some chan don't trigger (issue 277).

--- a/cmd/udpdump/udpdump.go
+++ b/cmd/udpdump/udpdump.go
@@ -53,16 +53,20 @@ func main() {
 		host = flag.Arg(0)
 
 		// If host ends in :portnum, split that off and update the port value
-		if a, b, hascolon := strings.Cut(host, ":"); hascolon {
-			host = a
-			if attachedport, err := strconv.Atoi(b); err != nil {
-				fmt.Printf("Cannot convert port '%s' to integer\n", b)
+		if pieces := strings.Split(host, ":"); len(pieces) > 1 {
+			if len(pieces) > 2 {
+				fmt.Printf("Cannot parse host '%s' with %d colon separators\n", host, len(pieces)-1)
+				return
+			}
+			if attachedport, err := strconv.Atoi(pieces[1]); err != nil {
+				fmt.Printf("Cannot convert port '%s' to integer\n", pieces[1])
 				return
 			} else {
 				if port != default_port && port != attachedport {
-					fmt.Printf("Cannot use -p argument and a conflicting host:port port\n")
+					fmt.Printf("Cannot use -p argument and a conflicting host:port pair\n")
 					return
 				}
+				host = pieces[0]
 				port = attachedport
 			}
 		}

--- a/cmd/udpdump/udpdump.go
+++ b/cmd/udpdump/udpdump.go
@@ -11,12 +11,14 @@ import (
 )
 
 func probe(npack int, endpoint string) error {
+	fmt.Printf("Probing %s for the first %d packets received...\n", endpoint, npack)
 	address, err := net.ResolveUDPAddr("udp", endpoint)
 	if err != nil {
 		return err
 	}
 	ServerConn, _ := net.ListenUDP("udp", address)
 	defer ServerConn.Close()
+
 	buf := make([]byte, 8192)
 	for i := 0; i < npack; i++ {
 		if _, _, err := ServerConn.ReadFromUDP(buf); err != nil {
@@ -29,7 +31,6 @@ func probe(npack int, endpoint string) error {
 			fmt.Printf("%s with %d frames for %d channels [%d-%d]\n", pack.String(),
 				pack.Frames(), nchan, chan0, chan0+nchan-1)
 		}
-		// fmt.Println("Received ", string(buf[0:n]), " from ", addr)
 	}
 	return nil
 }
@@ -37,15 +38,17 @@ func probe(npack int, endpoint string) error {
 func main() {
 	var npack int
 	var port int
-	host := "localhost"
+	const default_host = "localhost"
 	const default_port = 4000
+    host := default_host
 	flag.IntVar(&npack, "n", 10, "Number of packets to dump")
 	flag.IntVar(&port, "port", default_port, "Port to monitor")
 	flag.IntVar(&port, "p", default_port, "Port to monitor (shorthand)")
 
 	flag.Usage = func() {
-		fmt.Println("udpdump, for dumping the first N packets' headers")
-		fmt.Println("Usage: udpdump [flags] host[:port]")
+		fmt.Printf("udpdump, for dumping the first N packet headers, by default those from localhost:%d\n",
+			default_port)
+		fmt.Println("Usage: udpdump [flags] [host][:port]")
 		flag.PrintDefaults()
 	}
 	flag.Parse()
@@ -58,22 +61,25 @@ func main() {
 				fmt.Printf("Cannot parse host '%s' with %d colon separators\n", host, len(pieces)-1)
 				return
 			}
-			if attachedport, err := strconv.Atoi(pieces[1]); err != nil {
+			attachedport, err := strconv.Atoi(pieces[1])
+            if err != nil {
 				fmt.Printf("Cannot convert port '%s' to integer\n", pieces[1])
 				return
-			} else {
-				if port != default_port && port != attachedport {
-					fmt.Printf("Cannot use -p argument and a conflicting host:port pair\n")
-					return
-				}
-				host = pieces[0]
-				port = attachedport
 			}
+			if port != default_port && port != attachedport {
+				fmt.Printf("Cannot use -p argument and a conflicting host:port pair\n")
+				return
+			}
+			if len(pieces[0]) == 0 {
+                host = default_host
+            } else {
+				host = pieces[0]
+			}
+			port = attachedport
 		}
 	}
 
 	endpoint := fmt.Sprintf("%s:%4.4d", host, port)
-	fmt.Printf("Probing %s for first %d packets\n", endpoint, npack)
 	if err := probe(npack, endpoint); err != nil {
 		fmt.Printf("error: %v\n", err)
 	}

--- a/cmd/udpdump/udpdump.go
+++ b/cmd/udpdump/udpdump.go
@@ -1,76 +1,76 @@
 package main
 
 import (
-    "bytes"
-    "flag"
+	"bytes"
+	"flag"
 	"fmt"
 	"github.com/usnistgov/dastard/packets"
-    "net"
-    "strings"
-    "strconv"
+	"net"
+	"strconv"
+	"strings"
 )
 
 func probe(npack int, endpoint string) error {
-    address, err := net.ResolveUDPAddr("udp", endpoint)
-    if err != nil {
-        return err
-    }
-    ServerConn, _ := net.ListenUDP("udp", address)
+	address, err := net.ResolveUDPAddr("udp", endpoint)
+	if err != nil {
+		return err
+	}
+	ServerConn, _ := net.ListenUDP("udp", address)
 	defer ServerConn.Close()
 	buf := make([]byte, 8192)
-	for i := 0; i<npack; i++ {
+	for i := 0; i < npack; i++ {
 		if _, _, err := ServerConn.ReadFromUDP(buf); err != nil {
-            return err
-        }
-        if pack, err := packets.ReadPacket(bytes.NewReader(buf)); err != nil {
-            return err
-        } else {
-            nchan, chan0 := pack.ChannelInfo()
-            fmt.Printf("%s with %d frames for %d channels [%d-%d]\n", pack.String(),
-                pack.Frames(), nchan, chan0, chan0+nchan-1)
-        }
+			return err
+		}
+		if pack, err := packets.ReadPacket(bytes.NewReader(buf)); err != nil {
+			return err
+		} else {
+			nchan, chan0 := pack.ChannelInfo()
+			fmt.Printf("%s with %d frames for %d channels [%d-%d]\n", pack.String(),
+				pack.Frames(), nchan, chan0, chan0+nchan-1)
+		}
 		// fmt.Println("Received ", string(buf[0:n]), " from ", addr)
 	}
-    return nil
+	return nil
 }
 
 func main() {
-    var npack int
-    var port int
-    host := "localhost"
-    const default_port=4000
-    flag.IntVar(&npack, "n", 10, "Number of packets to dump")
-    flag.IntVar(&port, "port", default_port, "Port to monitor")
-    flag.IntVar(&port, "p", default_port, "Port to monitor (shorthand)")
+	var npack int
+	var port int
+	host := "localhost"
+	const default_port = 4000
+	flag.IntVar(&npack, "n", 10, "Number of packets to dump")
+	flag.IntVar(&port, "port", default_port, "Port to monitor")
+	flag.IntVar(&port, "p", default_port, "Port to monitor (shorthand)")
 
-    flag.Usage = func() {
+	flag.Usage = func() {
 		fmt.Println("udpdump, for dumping the first N packets' headers")
 		fmt.Println("Usage: udpdump [flags] host[:port]")
 		flag.PrintDefaults()
 	}
 	flag.Parse()
-    if flag.NArg() > 0 {
-        host = flag.Arg(0)
+	if flag.NArg() > 0 {
+		host = flag.Arg(0)
 
-        // If host ends in :portnum, split that off and update the port value
-        if a, b, hascolon := strings.Cut(host, ":"); hascolon {
-            host = a
-            if attachedport, err := strconv.Atoi(b); err != nil {
-                fmt.Printf("Cannot convert port '%s' to integer\n", b)
-                return
-            } else {
-                if port != default_port && port != attachedport {
-                    fmt.Printf("Cannot use -p argument and a conflicting host:port port\n")
-                    return
-                }
-                port = attachedport
-            }
-        }
-    }
+		// If host ends in :portnum, split that off and update the port value
+		if a, b, hascolon := strings.Cut(host, ":"); hascolon {
+			host = a
+			if attachedport, err := strconv.Atoi(b); err != nil {
+				fmt.Printf("Cannot convert port '%s' to integer\n", b)
+				return
+			} else {
+				if port != default_port && port != attachedport {
+					fmt.Printf("Cannot use -p argument and a conflicting host:port port\n")
+					return
+				}
+				port = attachedport
+			}
+		}
+	}
 
-    endpoint := fmt.Sprintf("%s:%4.4d", host, port)
-    fmt.Printf("Probing %s for first %d packets\n", endpoint, npack)
-    if err := probe(npack, endpoint); err != nil {
-        fmt.Printf("error: %v\n", err)
-    }
+	endpoint := fmt.Sprintf("%s:%4.4d", host, port)
+	fmt.Printf("Probing %s for first %d packets\n", endpoint, npack)
+	if err := probe(npack, endpoint); err != nil {
+		fmt.Printf("error: %v\n", err)
+	}
 }

--- a/cmd/udpdump/udpdump.go
+++ b/cmd/udpdump/udpdump.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+    "bytes"
+    "flag"
+	"fmt"
+	"github.com/usnistgov/dastard/packets"
+    "net"
+    "strings"
+    "strconv"
+)
+
+func probe(npack int, endpoint string) error {
+    address, err := net.ResolveUDPAddr("udp", endpoint)
+    if err != nil {
+        return err
+    }
+    ServerConn, _ := net.ListenUDP("udp", address)
+	defer ServerConn.Close()
+	buf := make([]byte, 8192)
+	for i := 0; i<npack; i++ {
+		if _, _, err := ServerConn.ReadFromUDP(buf); err != nil {
+            return err
+        }
+        if pack, err := packets.ReadPacket(bytes.NewReader(buf)); err != nil {
+            return err
+        } else {
+            nchan, chan0 := pack.ChannelInfo()
+            fmt.Printf("%s with %d frames for %d channels [%d-%d]\n", pack.String(),
+                pack.Frames(), nchan, chan0, chan0+nchan-1)
+        }
+		// fmt.Println("Received ", string(buf[0:n]), " from ", addr)
+	}
+    return nil
+}
+
+func main() {
+    var npack int
+    var port int
+    host := "localhost"
+    const default_port=4000
+    flag.IntVar(&npack, "n", 10, "Number of packets to dump")
+    flag.IntVar(&port, "port", default_port, "Port to monitor")
+    flag.IntVar(&port, "p", default_port, "Port to monitor (shorthand)")
+
+    flag.Usage = func() {
+		fmt.Println("udpdump, for dumping the first N packets' headers")
+		fmt.Println("Usage: udpdump [flags] host[:port]")
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+    if flag.NArg() > 0 {
+        host = flag.Arg(0)
+
+        // If host ends in :portnum, split that off and update the port value
+        if a, b, hascolon := strings.Cut(host, ":"); hascolon {
+            host = a
+            if attachedport, err := strconv.Atoi(b); err != nil {
+                fmt.Printf("Cannot convert port '%s' to integer\n", b)
+                return
+            } else {
+                if port != default_port && port != attachedport {
+                    fmt.Printf("Cannot use -p argument and a conflicting host:port port\n")
+                    return
+                }
+                port = attachedport
+            }
+        }
+    }
+
+    endpoint := fmt.Sprintf("%s:%4.4d", host, port)
+    fmt.Printf("Probing %s for first %d packets\n", endpoint, npack)
+    if err := probe(npack, endpoint); err != nil {
+        fmt.Printf("error: %v\n", err)
+    }
+}

--- a/cmd/udpdump/udpdump.go
+++ b/cmd/udpdump/udpdump.go
@@ -40,7 +40,7 @@ func main() {
 	var port int
 	const default_host = "localhost"
 	const default_port = 4000
-    host := default_host
+	host := default_host
 	flag.IntVar(&npack, "n", 10, "Number of packets to dump")
 	flag.IntVar(&port, "port", default_port, "Port to monitor")
 	flag.IntVar(&port, "p", default_port, "Port to monitor (shorthand)")
@@ -62,7 +62,7 @@ func main() {
 				return
 			}
 			attachedport, err := strconv.Atoi(pieces[1])
-            if err != nil {
+			if err != nil {
 				fmt.Printf("Cannot convert port '%s' to integer\n", pieces[1])
 				return
 			}
@@ -71,8 +71,8 @@ func main() {
 				return
 			}
 			if len(pieces[0]) == 0 {
-                host = default_host
-            } else {
+				host = default_host
+			} else {
 				host = pieces[0]
 			}
 			port = attachedport

--- a/global_config.go
+++ b/global_config.go
@@ -35,7 +35,7 @@ type BuildInfo struct {
 
 // Build is a global holding compile-time information about the build
 var Build = BuildInfo{
-	Version: "0.2.14",
+	Version: "0.2.15",
 	Githash: "no git hash computed",
 	Date:    "no build date computed",
 }

--- a/packets/packets.go
+++ b/packets/packets.go
@@ -80,7 +80,7 @@ func (p *Packet) ClearData() error {
 
 // String returns a string summarizing the packet's version, sequence number, and size.
 func (p *Packet) String() string {
-	return fmt.Sprintf("Packet v0x%2.2x 0x%8.8x  Size (%2d+%5d)", p.version,
+	return fmt.Sprintf("Packet v:0x%2.2x sn:0x%8.8x  Size (%2d+%4d)", p.version,
 		p.sequenceNumber, p.headerLength, p.payloadLength)
 }
 


### PR DESCRIPTION
This adds `cmd/udpdump/udpdump.go`, a separate main program that watches for Abaco-style packets from the UDP source specified at the command line. It prints key header information for the first N packets received.