### PR TITLE
Make distribution of Dastard easier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,13 @@ GOCLEAN=$(GOCMD) clean
 GOTEST=$(GOCMD) test
 BINARY_NAME=dastard
 
+.PHONY: all build install test clean run deps static
+
 LDFLAGS=-ldflags "-X main.buildDate=$(shell date -u '+%Y-%m-%d.%H:%M:%S.%Z') -X main.githash=$(shell git rev-parse --short HEAD)"
 build: $(BINARY_NAME)
 all: test build install
 
-$(BINARY_NAME): *.go cmd/dastard/dastard.go getbytes/*.go lancero/*.go ljh/*.go off/*.go packets/*.go ringbuffer/*.go
+$(BINARY_NAME): Makefile *.go cmd/dastard/dastard.go */*.go
 	$(GOBUILD) $(LDFLAGS) -o $(BINARY_NAME) cmd/dastard/dastard.go
 
 # make test needs to install deps, or Travis will fail
@@ -30,3 +32,14 @@ deps:
 
 install: build
 	cp -p $(BINARY_NAME) `go env GOPATH`/bin/
+
+# EXPERIMENTAL: build a statically linked dastard binary with "make static".
+# make static will _always_ rebuild the binary, and always with static linking
+# The magic below won't make static binaries on Mac OS X (Darwin) at this time, so error on Macs.
+STATICLDFLAGS=-ldflags "-linkmode external -extld g++ -extldflags '-static -lsodium'"
+OS_NAME := $(shell uname -s | tr A-Z a-z)
+static:
+ifeq ($(OS_NAME),darwin)
+	$(error Cannot build static binary on Mac OS)
+endif
+	$(GOBUILD) $(STATICLDFLAGS) $(LDFLAGS) -o $(BINARY_NAME) cmd/dastard/dastard.go

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,11 @@ GOCLEAN=$(GOCMD) clean
 GOTEST=$(GOCMD) test
 BINARY_NAME=dastard
 
+# The following uses the pure-Go "net" package netgo, instead of the usual link against C libraries.
+# Added March 7, 2023 to make the Dastard binary more portable. But you can change to "NETGO=" to
+# go back to the old way, if it seems useful.
+NETGO=-tags netgo
+
 .PHONY: all build install test clean run deps static
 
 LDFLAGS=-ldflags "-X main.buildDate=$(shell date -u '+%Y-%m-%d.%H:%M:%S.%Z') -X main.githash=$(shell git rev-parse --short HEAD)"
@@ -13,12 +18,12 @@ build: $(BINARY_NAME)
 all: test build install
 
 $(BINARY_NAME): Makefile *.go cmd/dastard/dastard.go */*.go
-	$(GOBUILD) $(LDFLAGS) -o $(BINARY_NAME) cmd/dastard/dastard.go
+	$(GOBUILD) $(LDFLAGS) $(NETGO) -o $(BINARY_NAME) cmd/dastard/dastard.go
 
 # make test needs to install deps, or Travis will fail
 test: deps
 	$(GOFMT)
-	$(GOTEST) -v ./...
+	$(GOTEST) $(NETGO) -v ./...
 
 clean:
 	$(GOCLEAN)
@@ -42,4 +47,4 @@ static:
 ifeq ($(OS_NAME),darwin)
 	$(error Cannot build static binary on Mac OS)
 endif
-	$(GOBUILD) $(STATICLDFLAGS) $(LDFLAGS) -o $(BINARY_NAME) cmd/dastard/dastard.go
+	$(GOBUILD) $(STATICLDFLAGS) $(LDFLAGS) $(NETGO) -o $(BINARY_NAME) cmd/dastard/dastard.go

--- a/README.md
+++ b/README.md
@@ -6,33 +6,35 @@ A data acquisition program for NIST transition-edge sensor (TES) microcalorimete
 ## Installation
 **Requires Go version 1.16** (released February 2021) or higher because [gonum](http://gonum.org/v1/gonum/mat) requires it. Dastard is tested automatically on versions 1.16 and LATEST (as of February 2023, Go version 1.20 is the most recent).
 
-We recommend always using the `Makefile` to build Dastard. That's not a typical go usage, but we have a very simple trick built into the `Makefile` that allows it to execute `go build` with linker arguments that override the default values of two global variables. By this step, we are able to get the git hash and the build date of the current version to be known inside Dastard. Hooray! The lesson is always use one of the following:
-```
+We recommend always using the `Makefile` to build Dastard. That's not a typical go usage, but we have a simple trick built into the `Makefile` that allows it to execute `go build` with linker arguments to set values of two global variables. By this step, we are able to get the git hash and the build date of the current version to be known inside Dastard. Hooray! The lesson is always use one of the following:
+```bash
 # To build locally and run that copy
 make build && ./dastard
 ```
 or
-```
-# To install as $HOME/go/bin/dastard
+```bash
+# To install as $(go env GOPATH)/bin/dastard, which is generally $HOME/go/bin/dastard
 make install   # implies make build
 dastard
 ```
 
 
-### Ubuntu 20, 18.04 and 16.04
+### Ubuntu 22.04, 20.04, 18.04, and (maybe?) 16.04
 
 One successful installation of the dependencies looked like this. Before pasting the following, be sure to run some
 simple command as sudo first; otherwise, the password entering step will screw up your multi-line paste.
-```
-# Dependencies (can skip if git is already installed)
+```bash
+# Dastard dependencies
 sudo apt-get -y update
 sudo apt-get install -y libsodium-dev libczmq-dev git gcc pkg-config
-# install go
+
+# Install go
 sudo add-apt-repository -y ppa:longsleep/golang-backports
 sudo apt-get -y update
 sudo apt-get -y install golang-go
 
 # Install Dastard as a development copy
+# (These lines should have an equivalent "go install" like maybe "go install gitub.com/usnistgov/dastard@latest"??)
 DASTARD_DEV_PATH=$(go env GOPATH)/src/github.com/usnistgov
 mkdir -p $DASTARD_DEV_PATH
 cd $DASTARD_DEV_PATH
@@ -41,8 +43,7 @@ cd dastard
 
 # Build, then try to run the local copy
 # Using the Makefile is preferred, because it's the only way we're aware of to get the git hash and build date
-# embedded in the built binary file.
-#
+# embedded in the built binary file. Run the new binary and check its version output.
 make build && ./dastard --version
 
 # Check whether the GOPATH is in your bash path. If not, update ~/.bashrc to make it so.
@@ -55,9 +56,10 @@ make install
 dastard --version
 ```
 
-The following seem to be out-of-date and apply only to Ubuntu 16.04 LTS, but just in case they
-are useful to you, here are the old instructions.
- ```
+Be sure to add `~/go/bin` to your `PATH` environment variable, or replace `~/go` with the results of your specific result when you run `go env GOPATH`.
+
+The following seem to be out-of-date and apply only to Ubuntu 16.04 LTS, but just in case they are useful to you, here are the old instructions.
+ ```bash
 sudo add-apt-repository -y 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-stable/xUbuntu_16.04/ ./'
 cd ~/Downloads
 wget http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-stable/xUbuntu_16.04/Release.key
@@ -66,12 +68,31 @@ sudo apt-get -y update
 sudo apt-get install -y libsodium-dev libczmq-dev git
 ```
 
+### Gentoo Linux
+
+The following seemed to work on a NASA balloon flight computer in March 2023:
+```bash
+USE="static-libs -systemd" emerge --ask net-libs/zeromq dev-libs/libsodium
+emerge --ask dev-vcs/git dev-lang/go
+mkdir -p $(go env GOPATH)/bin/
+```
+
+After this, follow the Ubuntu instructions starting with "# Install Dastard as a development copy". Make sure that the `update-path.sh` script worked and properly updated your `PATH` variable. That script hasn't been tested in Gentoo, as far as I know.
+
+
 ### MacOS dependencies (Homebrew or MacPorts)
 
 As appropriate, use one of
-```brew install go pkg-config czmq libsodium```
+
+```bash
+brew install go zmq libsodium pkg-config
+```
+
 or
-```sudo port install go czmq libsodium-dev pkg-config```
+
+```bash
+sudo port install go zmq libsodium-dev pkg-config
+```
 
 
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 ## DASTARD Versions
 
+**0.2.17** March 2023-
+* Add Gentoo instructions; add static compilation target to Makefile (issue 302).
+
 **0.2.16** February 2 2023
 * Make ROACH2 firmware for HOLMES team work (issue 297).
 * Add a veto possibility to the auto-trigger (issue 300).

--- a/global_config.go
+++ b/global_config.go
@@ -35,7 +35,7 @@ type BuildInfo struct {
 
 // Build is a global holding compile-time information about the build
 var Build = BuildInfo{
-	Version: "0.2.16",
+	Version: "0.2.17",
 	Githash: "no git hash computed",
 	Date:    "no build date computed",
 }

--- a/lancero_source.go
+++ b/lancero_source.go
@@ -8,7 +8,6 @@ import (
 	"math"
 	"os"
 	"os/signal"
-	"os/user"
 	"path/filepath"
 	"sort"
 	"time"
@@ -491,11 +490,10 @@ type cringeGlobals struct {
 
 // cringeGlobalsPath calculate the path to ~/.cringe/cringeGlobals.json by expanding the ~
 func cringeGlobalsCalculatePath() string {
-	usr, err := user.Current()
+	dir, err := os.UserHomeDir()
 	if err != nil {
 		panic(err) // I don't have a plan to handle this error meaningfully, so just panic, we can always change it later if we figure out how to deal with it
 	}
-	dir := usr.HomeDir
 	path := filepath.Join(dir, ".cringe", "cringeGlobals.json")
 	// log.Println("cringeGlobalsPath", path)
 	return path

--- a/rpc_server_test.go
+++ b/rpc_server_test.go
@@ -8,7 +8,6 @@ import (
 	"net/rpc"
 	"net/rpc/jsonrpc"
 	"os"
-	"os/user"
 	"strings"
 	"testing"
 	"time"
@@ -371,11 +370,11 @@ func configRunningSourceTests(client *rpc.Client, t *testing.T) {
 // verifyConfigFile checks that path/filename exists, and creates the directory
 // and file if it doesn't.
 func verifyConfigFile(path, filename string) error {
-	u, err := user.Current()
+	home, err := os.UserHomeDir()
 	if err != nil {
 		return err
 	}
-	path = strings.Replace(path, "$HOME", u.HomeDir, 1)
+	path = strings.Replace(path, "$HOME", home, 1)
 
 	// Create directory <path>, if needed
 	_, err = os.Stat(path)


### PR DESCRIPTION
4 small changes to make it easier to distribute Dastard:
* Stop using `os/user` package and use the modern way to find the user's home directory.
* Add the build tag `-tags netgo` to use the pure-Go network library.
* Add a make target `static` to build a statically linked binary (disabled on Mac OS X).
* Add Gentoo installation instructions.