### PR TITLE
Panic when lancero devices fail at key setup points

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,19 @@
 A data acquisition program for NIST transition-edge sensor (TES) microcalorimeters. Designed to replace the earlier programs `ndfb_server` and `matter` (see their [bitbucket repository](https://bitbucket.org/nist_microcal/nasa_daq)).
 
 ## Installation
-**Requires Go version 1.16** (released February 2021) or higher because [gonum](http://gonum.org/v1/gonum/mat) requires it. Dastard is tested automatically on versions 1.16 and LATEST (as of February 2023, Go version 1.20 is the most recent).
+**Requires Go version 1.16 or higher** (released February 2021) because [gonum](http://gonum.org/v1/gonum/mat) requires it. Dastard is tested automatically on versions 1.16 and LATEST (as of February 2023, Go version 1.20 is the most recent).
 
-We recommend always using the `Makefile` to build Dastard. That's not a typical go usage, but we have a simple trick built into the `Makefile` that allows it to execute `go build` with linker arguments to set values of two global variables. By this step, we are able to get the git hash and the build date of the current version to be known inside Dastard. Hooray! The lesson is always use one of the following:
+**Requires Go version no higher than 1.19** if you are using TDM systems with the Lancero device. We could not figure out how to make the device read correctly with Go 1.20 (as of April 20, 2023). If you run with Go 1.20+ and try to start a Lancero device, Dastard will panic. We hope and expect to fix this restriction in the future. For data sources other than Lancero, Go 1.20+ should be fine.
+
+**We recommend always using the `Makefile` to build Dastard.** That's not a typical go usage, but we have a simple trick built into the `Makefile` that allows it to execute `go build` with linker arguments to set values of two global variables. By this step, we are able to get the git hash and the build date of the current version to be known inside Dastard. Hooray! The lesson is always use one of the following:
 ```bash
 # To build locally and run that copy
 make build && ./dastard
 ```
 or
 ```bash
-# To install as $(go env GOPATH)/bin/dastard, which is generally $HOME/go/bin/dastard
-make install   # implies make build
+# To install as $(go env GOPATH)/bin/dastard, which generally means $HOME/go/bin/dastard
+make install   # also implies make build
 dastard
 ```
 
@@ -32,6 +34,11 @@ sudo apt-get install -y libsodium-dev libzmq3-dev git gcc pkg-config
 sudo add-apt-repository -y ppa:longsleep/golang-backports
 sudo apt-get -y update
 sudo apt-get -y install golang-go
+
+# If you need lancero-TDM, install go 1.19
+sudo apt-get -y install golang-1.19-go
+#
+# TODO: Somehow get the version go-1.19 into the path??
 
 # Install Dastard as a development copy
 # (These lines should have an equivalent "go install" like maybe "go install gitub.com/usnistgov/dastard@latest"??)

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 ## DASTARD Versions
 
+**0.2.18** April 2023-
+* Panic if run on Go 1.20 or higher with the lancero-TDM readout (issue 315).
+
 **0.2.17** March 7, 2023
 * Add Gentoo instructions; add static compilation target to Makefile (issue 302).
 * Switch to GitHub Actions for testing and deployment (issue 305, 308).

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -2,6 +2,7 @@
 
 **0.2.18** April 2023-
 * Panic if run on Go 1.20 or higher with the lancero-TDM readout (issue 315).
+* Return Lancero driver's ring buffer to 32 MB (undo issue 258); check return values, panic if needed (issue 316).
 
 **0.2.17** March 7, 2023
 * Add Gentoo instructions; add static compilation target to Makefile (issue 302).

--- a/cmd/dastard/dastard.go
+++ b/cmd/dastard/dastard.go
@@ -108,6 +108,7 @@ func main() {
 		fmt.Printf("This is DASTARD version %s\n", dastard.Build.Version)
 		fmt.Printf("Git commit hash: %s\n", githash)
 		fmt.Printf("Build time: %s\n", buildDate)
+		fmt.Printf("Built on go version %s\n", runtime.Version())
 		fmt.Printf("Running on %d CPUs.\n", runtime.NumCPU())
 		os.Exit(0)
 	}

--- a/global_config.go
+++ b/global_config.go
@@ -35,7 +35,7 @@ type BuildInfo struct {
 
 // Build is a global holding compile-time information about the build
 var Build = BuildInfo{
-	Version: "0.2.17",
+	Version: "0.2.18",
 	Githash: "no git hash computed",
 	Date:    "no build date computed",
 }

--- a/lancero/cmd/acquire/acquire.go
+++ b/lancero/cmd/acquire/acquire.go
@@ -165,7 +165,9 @@ func acquire(lan *lancero.Lancero) (bytesRead int, err error) {
 	}
 
 	// Start the adapter
-	err = lan.StartAdapter(2)
+	const timeoutSec = 2
+	const verbosity = 0
+	err = lan.StartAdapter(timeoutSec, verbosity)
 	if err != nil {
 		log.Println("Could not start adapter: ", err)
 		return

--- a/lancero/cmd/acquire/acquire.go
+++ b/lancero/cmd/acquire/acquire.go
@@ -46,15 +46,15 @@ func parseOptions() error {
 
 	switch {
 	case opt.period < 16:
-		return fmt.Errorf("Line sync period (%d) must be at least 16", opt.period)
+		return fmt.Errorf("line sync period (%d) must be at least 16", opt.period)
 	case opt.period >= 1024:
-		return fmt.Errorf("Line sync period (%d) must be < 1024", opt.period)
+		return fmt.Errorf("line sync period (%d) must be < 1024", opt.period)
 	case opt.mask > 0xffff:
-		return fmt.Errorf("Line sync period (0x%x) must be < 0xffff", opt.mask)
+		return fmt.Errorf("line sync period (0x%x) must be < 0xffff", opt.mask)
 	case opt.delay < 0 || opt.delay >= 32:
-		return fmt.Errorf("Line delay (%d) must be in [0,31]", opt.delay)
+		return fmt.Errorf("line delay (%d) must be in [0,31]", opt.delay)
 	case opt.threshold < 1:
-		return fmt.Errorf("Threshold (%d) must be at least 1", opt.threshold)
+		return fmt.Errorf("threshold (%d) must be at least 1", opt.threshold)
 	case opt.threshold < 1024:
 		log.Printf("WARNING: Threshold (%d) is recommended to be at least 1024", opt.threshold)
 	}
@@ -228,7 +228,7 @@ func acquire(lan *lancero.Lancero) (bytesRead int, err error) {
 						return
 					}
 					if n != len(buffer) {
-						err = fmt.Errorf("Wrote %d bytes, expected %d", n, len(buffer))
+						err = fmt.Errorf("wrote %d bytes, expected %d", n, len(buffer))
 						return
 					}
 				}

--- a/lancero/cmd/oddashtx/oddashtx.go
+++ b/lancero/cmd/oddashtx/oddashtx.go
@@ -18,7 +18,9 @@ func main() {
 		return
 	}
 
-	err = lan.StartAdapter(2)
+	const timeoutSec = 2
+	const verbosity = 0
+	err = lan.StartAdapter(timeoutSec, verbosity)
 	defer lan.StopAdapter()
 	if err != nil {
 		log.Println("Could not start adapter: ", err)

--- a/lancero/lancero.go
+++ b/lancero/lancero.go
@@ -91,7 +91,11 @@ func NewLancero(devnum int) (*Lancero, error) {
 	lan.device = dev
 	lan.collector = &collector{device: dev, simulated: false}
 	lan.adapter = &adapter{device: dev, verbosity: 3}
-	lan.ChangeRingBuffer(256000000, 128000000)
+
+	OneMB := 1024 * 1024
+	if err := lan.ChangeRingBuffer(32*OneMB, 16*OneMB); err != nil {
+		panic(err)
+	}
 
 	lan.adapter.status()
 	lan.adapter.inspect()
@@ -101,7 +105,10 @@ func NewLancero(devnum int) (*Lancero, error) {
 
 // ChangeRingBuffer re-sizes the adapter's ring buffer.
 func (lan *Lancero) ChangeRingBuffer(length, threshold int) error {
-	return lan.adapter.allocateRingBuffer(length, threshold)
+	if err := lan.adapter.allocateRingBuffer(length, threshold); err != nil {
+		panic(err)
+	}
+	return nil
 }
 
 // Close releases all resources used by this lancero device.

--- a/lancero/lancero.go
+++ b/lancero/lancero.go
@@ -46,21 +46,21 @@ type Lanceroer interface {
 func verifyGoVersion() error {
 	ver := runtime.Version()
 	if !strings.HasPrefix(ver, "go") {
-		return fmt.Errorf("cannot detect version: runtime.Version() returned '%s' but expected it to start with go*", ver)
+		return fmt.Errorf("cannot detect Go version: runtime.Version() returned '%s' but expected it to start with go*", ver)
 	}
 
 	parts := strings.Split(ver[2:], ".")
 	if !(parts[0] == "1") || !(len(parts) > 1) {
-		return fmt.Errorf("cannot detect version: runtime.Version() returned '%s' but expected it to start with go1.*", ver)
+		return fmt.Errorf("cannot detect Go version: runtime.Version() returned '%s' but expected it to start with go1.*", ver)
 	}
 
 	minor, err := strconv.Atoi(parts[1])
 	if err != nil {
-		return fmt.Errorf("cannot detect version: runtime.Version() returned '%s' but expected it to start with go1.<number>", ver)
+		return fmt.Errorf("cannot detect Go version: runtime.Version() returned '%s' but expected it to start with go1.<number>", ver)
 	}
 
 	if minor >= 20 {
-		return fmt.Errorf("runtime.Version() says Golang version is '%s', but we require 1.19 or lower in order to use lancero devices", ver)
+		return fmt.Errorf("runtime.Version() says Go version is '%s', but we require 1.19 or lower in order to use lancero devices", ver)
 	}
 	return nil
 }
@@ -78,7 +78,7 @@ type Lancero struct {
 // than 1 card in the computer. Usually, you'll use 0 here.
 func NewLancero(devnum int) (*Lancero, error) {
 
-	// Make sure not using Go 1.20+, b/c that's incompatible with the Lancero device
+	// Panic if program was compiled with Go 1.20+, b/c that's incompatible with the Lancero device
 	if err := verifyGoVersion(); err != nil {
 		panic(err)
 	}

--- a/lancero/lancero.go
+++ b/lancero/lancero.go
@@ -90,9 +90,7 @@ func NewLancero(devnum int) (*Lancero, error) {
 	}
 	lan.device = dev
 	lan.collector = &collector{device: dev, simulated: false}
-	lan.adapter = &adapter{device: dev}
-	// lan.adapter.verbosity = 3
-	// lan.adapter.allocateRingBuffer(1<<24, 1<<23)
+	lan.adapter = &adapter{device: dev, verbosity: 3}
 	lan.ChangeRingBuffer(256000000, 128000000)
 
 	lan.adapter.status()

--- a/lancero/lancero.go
+++ b/lancero/lancero.go
@@ -24,7 +24,7 @@ import (
 type Lanceroer interface {
 	ChangeRingBuffer(int, int) error
 	Close() error
-	StartAdapter(int) error
+	StartAdapter(int, int) error
 	StopAdapter() error
 	CollectorConfigure(int, int, uint32, int) error
 	StartCollector(bool) error
@@ -122,12 +122,13 @@ func (lan *Lancero) Close() error {
 }
 
 // StartAdapter starts the ring buffer adapter, waiting up to waitSeconds sec for it to work.
-func (lan *Lancero) StartAdapter(waitSeconds int) error {
+func (lan *Lancero) StartAdapter(waitSeconds, verbosity int) error {
 	// Panic if program was compiled with Go 1.20+, b/c that's incompatible with the Lancero device
 	if err := verifyGoVersion(); err != nil {
 		panic(err)
 	}
 
+	lan.adapter.verbosity = verbosity
 	return lan.adapter.start(waitSeconds)
 }
 

--- a/lancero/lancero_adapter.go
+++ b/lancero/lancero_adapter.go
@@ -233,8 +233,7 @@ func (a *adapter) start(waitSeconds int) error {
 }
 
 func (a *adapter) stop() error {
-	verbose := a.verbosity >= 3
-	verbose = true
+	verbose := (a.verbosity >= 3)
 	if verbose {
 		log.Println("adapter.stop(): setting RUN | FLUSH bits.")
 	}

--- a/lancero/lancero_adapter.go
+++ b/lancero/lancero_adapter.go
@@ -127,6 +127,9 @@ func (a *adapter) allocateRingBuffer(length, threshold int) error {
 	const PAGEALIGN C.size_t = 4096
 	a.freeBuffer()
 	a.buffer = C.posixMemAlign(PAGEALIGN, C.size_t(length))
+	if a.buffer == nil {
+		return fmt.Errorf("a.buffer = C.posixMemAlign returns no valid buffer")
+	}
 
 	a.stop()
 	if a.verbosity >= 3 {

--- a/lancero/lancero_device.go
+++ b/lancero/lancero_device.go
@@ -75,7 +75,7 @@ type lanceroDevice struct {
 // possible.
 func openLanceroDevice(devnum int) (dev *lanceroDevice, err error) {
 	dev = new(lanceroDevice)
-	// dev.verbosity = 3
+	dev.verbosity = 3
 
 	// Convert device component name to a devfs path. If devnum is negative, omit
 	// it (for compatibility with older driver versions). Otherwise, append it (for
@@ -130,7 +130,7 @@ func (dev *lanceroDevice) preadUint32(file *os.File, offset int64) (uint32, erro
 	result := make([]byte, 4)
 	n, err := file.ReadAt(result, offset)
 	if n < 4 || err != nil {
-		return 0, fmt.Errorf("Could not read file %s offset: 0x%x", file.Name(), offset)
+		return 0, fmt.Errorf("could not read file %s offset: 0x%x", file.Name(), offset)
 	}
 	return binary.LittleEndian.Uint32(result[0:]), nil
 }
@@ -184,7 +184,7 @@ func (dev *lanceroDevice) pwriteUint32(file *os.File, offset int64, value uint32
 	binary.LittleEndian.PutUint32(bytes, value)
 	n, err := file.WriteAt(bytes, offset)
 	if n < 4 || err != nil {
-		return fmt.Errorf("Could not write file %s offset: 0x%x, value: 0x%x", file.Name(), offset, value)
+		return fmt.Errorf("could not write file %s offset: 0x%x, value: 0x%x", file.Name(), offset, value)
 	}
 	return nil
 }
@@ -299,8 +299,7 @@ func (dev *lanceroDevice) cyclicStart(buffer *C.char, bufferLength uint32, waitS
 
 // Stop the cyclic SGDMA.
 func (dev *lanceroDevice) cyclicStop() error {
-	verbose := dev.verbosity >= 3
-	verbose = true
+	verbose := (dev.verbosity >= 3)
 	var BUSYFLAG uint32 = 1
 
 	// Read engine status

--- a/lancero/lancero_test.go
+++ b/lancero/lancero_test.go
@@ -48,7 +48,9 @@ func testLanceroerSubroutine(lan Lanceroer, t *testing.T) (int, int, int, error)
 	// 	t.Errorf("%v", err)
 	// }
 	var nrows, ncols, linePeriod int
-	if err := lan.StartAdapter(2); err != nil {
+	const timeoutSec = 2
+	const verbosityIsIgnored = 0
+	if err := lan.StartAdapter(timeoutSec, verbosityIsIgnored); err != nil {
 		t.Error("failed to start lancero (driver problem):", err)
 	}
 	lan.InspectAdapter()

--- a/lancero/no_hardware.go
+++ b/lancero/no_hardware.go
@@ -57,7 +57,7 @@ func (lan *NoHardware) Close() error {
 }
 
 // StartAdapter errors if already started
-func (lan *NoHardware) StartAdapter(waitSeconds int) error {
+func (lan *NoHardware) StartAdapter(waitSeconds, verbosity int) error {
 	if lan.isStarted {
 		return fmt.Errorf("NoHardware.StartAdapter: already started: id %v", lan.idNum)
 	}

--- a/lancero_source.go
+++ b/lancero_source.go
@@ -375,7 +375,9 @@ func (device *LanceroDevice) sampleCard() error {
 		return fmt.Errorf("failed to change ring buffer size (driver problem): %v", err)
 	}
 
-	if err := lan.StartAdapter(2); err != nil {
+	const timeoutSeconds = 2
+	const verbosity = 3
+	if err := lan.StartAdapter(timeoutSeconds, verbosity); err != nil {
 		return fmt.Errorf("failed to start lancero (driver problem): %v", err)
 	}
 
@@ -548,8 +550,9 @@ func (ls *LanceroSource) StartRun() error {
 		}
 
 		// 2. Start the adapter and collector components in firmware
-		const Timeout int = 2 // seconds
-		if err := lan.StartAdapter(Timeout); err != nil {
+		const timeoutSeconds = 2
+		const verbosity = 0
+		if err := lan.StartAdapter(timeoutSeconds, verbosity); err != nil {
 			return fmt.Errorf("failed to start lancero (driver problem): %v", err)
 		}
 		device.adapRunning = true


### PR DESCRIPTION
Also change the lancero.adapter so it has high verbosity at first (in the sample-card phase) and zero verbosity during the regular data-acquisition phase.

Fixes #316.