### PR TITLE
Workaround for the go 1.20 library bug

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -2,6 +2,7 @@
 
 **0.2.19** May 2023-
 * Fix unchecked error in starting Abaco sources (issue 321).
+* Workaround for bug in Go library `os.OpenFile` (issue 324).
 
 **0.2.18** April 24, 2023
 * Panic if run on Go 1.20 or higher with the lancero-TDM readout (issue 315).

--- a/lancero/lancero.go
+++ b/lancero/lancero.go
@@ -11,8 +11,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
@@ -41,29 +39,6 @@ type Lanceroer interface {
 // adapter (for the ring buffer)
 // collector (for the data serialization engine)
 // lanceroDevice (for the low-level register communication). This is lancero in C++
-
-// verifyGoVersion returns error if the go version is 1.20 or higher, or cannot be determined from runtime.Version()
-func verifyGoVersion() error {
-	ver := runtime.Version()
-	if !strings.HasPrefix(ver, "go") {
-		return fmt.Errorf("cannot detect Go version: runtime.Version() returned '%s' but expected it to start with go*", ver)
-	}
-
-	parts := strings.Split(ver[2:], ".")
-	if !(parts[0] == "1") || !(len(parts) > 1) {
-		return fmt.Errorf("cannot detect Go version: runtime.Version() returned '%s' but expected it to start with go1.*", ver)
-	}
-
-	minor, err := strconv.Atoi(parts[1])
-	if err != nil {
-		return fmt.Errorf("cannot detect Go version: runtime.Version() returned '%s' but expected it to start with go1.<number>", ver)
-	}
-
-	if minor >= 20 {
-		return fmt.Errorf("runtime.Version() says Go version is '%s', but we require 1.19 or lower in order to use lancero devices", ver)
-	}
-	return nil
-}
 
 // Lancero is the high-level object used to manipulate all user-space functions of
 // the Lancero device driver.
@@ -123,11 +98,6 @@ func (lan *Lancero) Close() error {
 
 // StartAdapter starts the ring buffer adapter, waiting up to waitSeconds sec for it to work.
 func (lan *Lancero) StartAdapter(waitSeconds, verbosity int) error {
-	// Panic if program was compiled with Go 1.20+, b/c that's incompatible with the Lancero device
-	if err := verifyGoVersion(); err != nil {
-		panic(err)
-	}
-
 	lan.adapter.verbosity = verbosity
 	return lan.adapter.start(waitSeconds)
 }
@@ -149,11 +119,6 @@ func (lan *Lancero) CollectorConfigure(linePeriod, dataDelay int, channelMask ui
 
 // StartCollector starts the data serializer.
 func (lan *Lancero) StartCollector(simulate bool) error {
-	// Panic if program was compiled with Go 1.20+, b/c that's incompatible with the Lancero device
-	if err := verifyGoVersion(); err != nil {
-		panic(err)
-	}
-
 	return lan.collector.start(simulate)
 }
 

--- a/lancero/lancero_adapter.go
+++ b/lancero/lancero_adapter.go
@@ -4,12 +4,6 @@ package lancero
 // #include <stdlib.h>
 // #include <stdio.h>
 // #include <string.h>
-//
-// char* posixMemAlign(size_t alignment, size_t size) {
-//     void *vout;
-//    ssize_t _ = posix_memalign(&vout, alignment, size);
-//     return (char *)vout;
-// }
 import "C"
 
 import (
@@ -126,9 +120,14 @@ func (a *adapter) allocateRingBuffer(length, threshold int) error {
 	a.thresholdLevel = uint32(threshold)
 	const PAGEALIGN C.size_t = 4096
 	a.freeBuffer()
-	a.buffer = C.posixMemAlign(PAGEALIGN, C.size_t(length))
-	if a.buffer == nil {
-		return fmt.Errorf("a.buffer = C.posixMemAlign returns no valid buffer")
+	var read_buf unsafe.Pointer
+	retval := C.posix_memalign(&read_buf, PAGEALIGN, C.size_t(length))
+	a.buffer = (*C.char)(read_buf)
+	if a.buffer == nil || retval != 0 {
+		return fmt.Errorf("a.buffer = C.posixMemAlign returns no valid buffer (retval=%v)", retval)
+	}
+	if C.size_t(uintptr(unsafe.Pointer(a.buffer)))%PAGEALIGN != 0 {
+		return fmt.Errorf("a.buffer = C.posixMemAlign returns unaligned buffer at %p", a.buffer)
 	}
 
 	a.stop()
@@ -171,10 +170,7 @@ func (a *adapter) availableBuffer() (buffer []byte, timefix time.Time, err error
 	length2 := C.int(a.writeIndex)
 	buffer = make([]byte, length1+length2)
 	C.memcpy(unsafe.Pointer(&buffer[0]), unsafe.Pointer(uintptr(unsafe.Pointer(a.buffer))+uintptr(a.readIndex)), C.size_t(length1))
-	// buffer = C.GoBytes(unsafe.Pointer(uintptr(unsafe.Pointer(a.buffer))+uintptr(a.readIndex)), length1+length2)
 	if length2 > 0 {
-		// log.Printf("\tjoining buffers of length %7d+%7d\n", length1, length2)
-		// buffer = append(buffer, C.GoBytes(unsafe.Pointer(a.buffer), length2)...)
 		C.memcpy(unsafe.Pointer(&buffer[length1]), unsafe.Pointer(a.buffer), C.size_t(length2))
 	}
 	return


### PR DESCRIPTION
* Fixes #324. 
* Removes some unnecessary included C code to wrap C functions for cgo. Keep it simple(r).
* Remove the global test that causes panic if you run Lancero sources and complied with Go 1.20.