### PR TITLE
Go back to `C.read(...)`.

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -3,6 +3,7 @@
 **0.2.19** May 2023-
 * Fix unchecked error in starting Abaco sources (issue 321).
 * Workaround for bug in Go library `os.OpenFile` (issue 324).
+* Fix fact that the workaround was yielding zeros from lancero source (issue 326).
 
 **0.2.18** April 24, 2023
 * Panic if run on Go 1.20 or higher with the lancero-TDM readout (issue 315).

--- a/lancero/lancero_device.go
+++ b/lancero/lancero_device.go
@@ -4,10 +4,6 @@
 package lancero
 
 // #include <unistd.h>
-//
-// ssize_t readWrap(int fd, void *buf, size_t nbyte) {
-//     return read(fd, buf, nbyte);
-// }
 import "C"
 
 import (
@@ -231,7 +227,7 @@ func (dev *lanceroDevice) cyclicStart(buffer *C.char, bufferLength uint32, waitS
 	// Calling a C read operation on the SGDMA file descriptor is (apparently) how
 	// we indicate the address of our DMA ring buffer to the lancero device driver.
 	fd := dev.FileSGDMA.Fd()
-	csize := C.readWrap(C.int(fd), unsafe.Pointer(buffer), C.size_t(bufferLength))
+	csize := C.read(C.int(fd), unsafe.Pointer(buffer), C.size_t(bufferLength))
 	n := uint32(csize)
 	if n < bufferLength {
 		return fmt.Errorf("cyclicStart(): could not start SGDMA")

--- a/lancero/lancero_device.go
+++ b/lancero/lancero_device.go
@@ -4,6 +4,10 @@
 package lancero
 
 // #include <unistd.h>
+//
+// ssize_t readWrap(int fd, void *buf, size_t nbyte) {
+//     return read(fd, buf, nbyte);
+// }
 import "C"
 
 import (
@@ -16,8 +20,6 @@ import (
 	"syscall"
 	"time"
 	"unsafe"
-
-	"golang.org/x/sys/unix"
 )
 
 // EnumerateLanceroDevices returns a list of lancero device numbers that exist
@@ -229,10 +231,10 @@ func (dev *lanceroDevice) cyclicStart(buffer *C.char, bufferLength uint32, waitS
 	// Calling a C read operation on the SGDMA file descriptor is (apparently) how
 	// we indicate the address of our DMA ring buffer to the lancero device driver.
 	fd := dev.FileSGDMA.Fd()
-	gobuffer := C.GoBytes(unsafe.Pointer(buffer), C.int(bufferLength))
-	n, err := unix.Read(int(fd), gobuffer)
-	if (n < int(bufferLength)) || (err != nil) {
-		return fmt.Errorf("cyclicStart(): could not start SGDMA (n=%v, err=%v)", n, err)
+	csize := C.readWrap(C.int(fd), unsafe.Pointer(buffer), C.size_t(bufferLength))
+	n := uint32(csize)
+	if n < bufferLength {
+		return fmt.Errorf("cyclicStart(): could not start SGDMA")
 	}
 	value, err := dev.readControl(0x200)
 	if err != nil {


### PR DESCRIPTION
Fixes #326. Problem was that we were _apparently_ starting the Lancero device successfully, but it was actually reading all zeros. Oops.

By returning to the cgo call to the C library function `read(...)`, we can make it read real, nontrivial data.