### PR TITLE
µMUX external trigger at "row rate" =64 x frame

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 ## DASTARD Versions
 
+**0.3.2** February 2024-
+* Make external trigger resolution 64x finer (issue 335).
+
 **0.3.1** February 3, 2024
 * Add configuration to invert an arbitrary subset of Abaco channels (issue 330).
 * Process UDP packets containing external trigger information (issue 331).

--- a/global_config.go
+++ b/global_config.go
@@ -35,7 +35,7 @@ type BuildInfo struct {
 
 // Build is a global holding compile-time information about the build
 var Build = BuildInfo{
-	Version: "0.3.1",
+	Version: "0.3.2",
 	Githash: "no git hash computed",
 	Date:    "no build date computed",
 }

--- a/lancero_source.go
+++ b/lancero_source.go
@@ -93,6 +93,7 @@ func NewLanceroSource() (*LanceroSource, error) {
 	if source.ncards == 0 && len(devnums) > 0 {
 		return source, fmt.Errorf("could not open any of /dev/lancero_user*, though devnums %v exist", devnums)
 	}
+
 	return source, nil
 }
 
@@ -340,6 +341,7 @@ func (ls *LanceroSource) PrepareChannels() error {
 	thisColFirstCnum := cnum - ls.chanSepColumns
 	ls.groupKeysSorted = make([]GroupIndex, 0)
 	for _, device := range ls.active {
+		ls.rowFrameRatio = device.nrows
 		if ls.chanSepCards > 0 {
 			cnum = device.devnum*ls.chanSepCards + ls.firstRowChanNum
 			thisColFirstCnum = cnum - ls.chanSepColumns


### PR DESCRIPTION
The µMUX external triggers need to be written with much finer timing resolution. This PR increases timing resolution by 64x (which is 256 ns timestamp resolution for the HEATES 2024 experiment). Fixes #335.

This has been tested at. J-PARC MLF beamline D2.