### PR TITLE
Add subframe timing info to LJH and OFF file headers

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -2,7 +2,7 @@
 
 **0.3.2** February 2024-
 * Make external trigger resolution 64x finer (issue 335).
-* Add subframe info to LJH and OFF headers (issue 337).
+* Add subframe info to LJH and OFF headers; use subframe language throughout code (issue 337).
 
 **0.3.1** February 3, 2024
 * Add configuration to invert an arbitrary subset of Abaco channels (issue 330).

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -2,6 +2,7 @@
 
 **0.3.2** February 2024-
 * Make external trigger resolution 64x finer (issue 335).
+* Add subframe info to LJH and OFF headers (issue 337).
 
 **0.3.1** February 3, 2024
 * Add configuration to invert an arbitrary subset of Abaco channels (issue 330).

--- a/abaco.go
+++ b/abaco.go
@@ -688,7 +688,6 @@ func NewAbacoSource() (*AbacoSource, error) {
 	source.groups = make(map[GroupIndex]*AbacoGroup)
 	source.eTrigPackets = make([]*packets.Packet, 0)
 	source.channelsPerPixel = 1
-	source.rowFrameRatio = abacoPseudoRowRate
 
 	// Probe for ring buffers that exist, and set up possible receivers.
 	deviceCodes, err := enumerateAbacoRings()
@@ -714,6 +713,12 @@ func NewAbacoSource() (*AbacoSource, error) {
 // Delete closes the ring buffers for all AbacoRings.
 func (as *AbacoSource) Delete() {
 	as.closeDevices()
+}
+
+// subframeDivisions is the ratio of subframe rate to frame rate (for external trigger purposes)
+// Specific sources can override this
+func (as *AbacoSource) subframeDivisions() int {
+	return abacoPseudoRowRate
 }
 
 // AbacoSourceConfig holds the arguments needed to call AbacoSource.Configure by RPC.
@@ -917,6 +922,7 @@ func (as *AbacoSource) PrepareChannels() error {
 	// as rows 0...g.nchan-1.
 	as.chanNames = make([]string, 0, as.nchan)
 	as.chanNumbers = make([]int, 0, as.nchan)
+	as.subframeOffsets = make([]int, as.nchan) // all zeros for Abaco sources
 	as.rowColCodes = make([]RowColCode, 0, as.nchan)
 	ncol := len(as.groups)
 	for col, g := range as.groupKeysSorted {

--- a/data_source.go
+++ b/data_source.go
@@ -584,7 +584,8 @@ func (ds *AnySource) HandleExternalTriggers(externalTriggerRowcounts []int64) er
 		ds.writingState.externalTriggerFileBufferedWriter = bufio.NewWriter(ds.writingState.externalTriggerFile)
 		// write header
 		msg := fmt.Sprintf("# external trigger rowcounts as int64 binary data follows, "+
-			"rowcounts = framecounts*nrow+row (nrow=%4d)\n", ds.subframeDivisions)
+			"subframeCounts = frameCounts*subframeDivisions+subframeOffset (subframeDivisions=%4d)\n",
+			ds.subframeDivisions)
 		_, err1 := ds.writingState.externalTriggerFileBufferedWriter.WriteString(msg)
 		if err1 != nil {
 			return fmt.Errorf("cannot write header to externalTriggerFileBufferedWriter, err %v", err)

--- a/data_source.go
+++ b/data_source.go
@@ -752,7 +752,8 @@ func (ds *AnySource) writeControlStart(config *WriteControlConfig) error {
 		if config.WriteLJH22 {
 			filename := fmt.Sprintf(filenamePattern, dsp.Name, "ljh")
 			dsp.DataPublisher.SetLJH22(i, dsp.NPresamples, dsp.NSamples, fps,
-				timebase, DastardStartTime, nrows, ncols, ds.nchan, rowNum, colNum, filename,
+				timebase, DastardStartTime, nrows, ncols, ds.nchan, ds.subframeDivisions(),
+				rowNum, colNum, ds.subframeOffsets[i], filename,
 				ds.name, ds.chanNames[i], ds.chanNumbers[i], pixel)
 		}
 		if config.WriteOFF && dsp.HasProjectors() {
@@ -766,7 +767,8 @@ func (ds *AnySource) writeControlStart(config *WriteControlConfig) error {
 		}
 		if config.WriteLJH3 {
 			filename := fmt.Sprintf(filenamePattern, dsp.Name, "ljh3")
-			dsp.DataPublisher.SetLJH3(i, timebase, nrows, ncols, filename)
+			dsp.DataPublisher.SetLJH3(i, timebase, nrows, ncols, ds.subframeDivisions(),
+				ds.subframeOffsets[i], filename)
 		}
 	}
 	return ds.writingState.Start(filenamePattern, path)

--- a/data_source_test.go
+++ b/data_source_test.go
@@ -191,19 +191,17 @@ func TestWritingFiles(t *testing.T) {
 		t.Error("Stop did not result in !HasLJH3")
 	}
 
-	if true { // block prevents variable from persisting (what variable?)
-		fileContents, err2 := os.ReadFile(experimentStateFilename)
-		fileContentsStr := string(fileContents)
-		if err2 != nil {
-			t.Error(err2)
-		}
-		expectFileContentsStr := "# unix time in nanoseconds, state label\n1538424162462127037, START\n1538174046828690465, AQ7\n1538424428433771969, STOP\n"
-		if !strings.HasPrefix(fileContentsStr, "# unix time in nanoseconds, state label\n") ||
-			!strings.Contains(fileContentsStr, ", START\n") ||
-			!strings.Contains(fileContentsStr, ", AQ7\n") ||
-			!strings.HasSuffix(fileContentsStr, ", STOP\n") ||
-			len(expectFileContentsStr) != len(fileContentsStr) {
-			t.Errorf("have\n%v\nwant (except timestamps should disagree)\n%v\n", fileContentsStr, expectFileContentsStr)
-		}
+	fileContents, err2 := os.ReadFile(experimentStateFilename)
+	fileContentsStr := string(fileContents)
+	if err2 != nil {
+		t.Error(err2)
+	}
+	expectFileContentsStr := "# unix time in nanoseconds, state label\n1538424162462127037, START\n1538174046828690465, AQ7\n1538424428433771969, STOP\n"
+	if !strings.HasPrefix(fileContentsStr, "# unix time in nanoseconds, state label\n") ||
+		!strings.Contains(fileContentsStr, ", START\n") ||
+		!strings.Contains(fileContentsStr, ", AQ7\n") ||
+		!strings.HasSuffix(fileContentsStr, ", STOP\n") ||
+		len(expectFileContentsStr) != len(fileContentsStr) {
+		t.Errorf("have\n%v\nwant (except timestamps should disagree)\n%v\n", fileContentsStr, expectFileContentsStr)
 	}
 }

--- a/data_source_test.go
+++ b/data_source_test.go
@@ -190,7 +190,8 @@ func TestWritingFiles(t *testing.T) {
 	if ds.processors[0].DataPublisher.HasLJH3() {
 		t.Error("Stop did not result in !HasLJH3")
 	}
-	if true { // prevent variable from persisting
+
+	if true { // block prevents variable from persisting (what variable?)
 		fileContents, err2 := os.ReadFile(experimentStateFilename)
 		fileContentsStr := string(fileContents)
 		if err2 != nil {

--- a/doc/LJH.md
+++ b/doc/LJH.md
@@ -29,23 +29,29 @@ This line indicates that the file is based on format described here.
 Save File Format Version: 2.2.0
 Software Version: DASTARD version 0.2.15
 Software Git Hash: 85ab821
-Data source: Abaco
+Data source: Lancero
 ```
 
-These lines uniquely identify the exact format, so the interpreting program can adapt. While the first line should be sufficient for this purpose, the second and third lines take in the possibility that a particular program may have a bug. The interpreting program may be aware of this bug and compensate. The Data source is meant for later human reference.
+These lines uniquely identify the exact format, so the interpreting program can adapt. While the first line should be sufficient for this purpose, the second and third lines take in the possibility that a particular program may have a bug. The interpreting program may be aware of this bug and compensate. The Data source is meant for later human reference: values include Abaco, Lancero, and Roach.
 
 ```
-Number of rows: 74
+Number of rows: 32
 Number of columns: 1
-Row number (from 0-73 inclusive): 12
+Row number (from 0-31 inclusive): 12
 Column number (from 0-0 inclusive): 0
-Number of channels: 74
+Number of channels: 32
 Channel name: chan12
 Channel: 12
 ChannelIndex (in dastard): 12
+Subframe divisions: 32
+Subframe offset: 12
 ```
 
 Dastard inserts this information to help downstream analysis tools understand the array being used when this file was acquired. 
+
+In February 2024, we added the Subframe divisions/offset tags. 
+* _Subframe divisions_ indicates the speed of the subframe counter, which is used for timing external triggers. It will be the row rate/frame rate ratio (i.e., the number of rows) for Lancero sources, and some arbitrary multiplier like 64 for other sources. 
+* _Subframe offset_ means how many subframe divisions delayed is THIS channel w.r.t. the frame clock. It will be the row number for Lancero sources, and 0 for other sources that read all channels simultaneously.
 
 ```
 Digitized Word Size in Bytes: 2
@@ -125,7 +131,7 @@ If you read an LJH file until the characters `#End of Header`, then the remainde
 Each record starts with a 16-byte time marker. The record's waveform data consists of the next L*M bytes, where L is the number of samples (`Total Samples:` value from the header) and M is the number of bytes per sample (`Digitized Word Size in Bytes:` from the header). M is always 2 bytes per sample, in practice.
 * The full record's length is **16+L*M** .
 * All values in the data record are little endian.
-* The first 8-byte word is the row counter. It counts the number of _row_ times read out since the server started. If the server has to resynchronize on the raw data, then the row counter will be incremented by an _estimate_ to account for the time missed.
+* The first 8-byte word is the subframe counter. It counts the number of _subframe_ divisions read out since the server started. If the server has to resynchronize on the raw data, then the subframe counter will be incremented by an _estimate_ to account for the time missed.
 * The second 8-byte word is the POSIX microsecond time, i.e., the time in microseconds since 1 January 1970 00:00 UT. (Warning: this will overflow in 292,226 years if you interpret it as a signed number.)
 * The next L words (of M bytes each) are the data record, as a signed or unsigned integer. (Typically, we use signed for the TDM error signal and unsigned for the TDM feedback, and unsigned for µMUX data.)
 

--- a/lancero/no_hardware.go
+++ b/lancero/no_hardware.go
@@ -42,7 +42,7 @@ func NewNoHardware(ncols int, nrows int, linePeriod int) (*NoHardware, error) {
 	return &lan, nil
 }
 
-// ChangeRingBuffer doesnt error
+// ChangeRingBuffer doesn't error
 func (lan *NoHardware) ChangeRingBuffer(length, threshold int) error {
 	return nil
 }

--- a/ljh/ljh.go
+++ b/ljh/ljh.go
@@ -174,24 +174,24 @@ Number of channels: %d
 Channel name: %s
 Channel: %d
 ChannelIndex (in dastard): %d
+Subframe divisions: %d
+Subframe offset: %d
 Digitized Word Size In Bytes: 2
 Presamples: %d
 Total Samples: %d
 Number of samples per point: %d
-Subframe divisions: %d
 Timestamp offset (s): %.6f
 Server Start Time: %s
 First Record Time: %s
-Subframe offset: %d
 Pixel X Position: %d
 Pixel Y Position: %d
 Pixel Name: %s
 Timebase: %e
 #End of Header
 `, w.DastardVersion, w.GitHash, w.SourceName, rowColText, w.NumberOfChans,
-		w.ChanName, w.ChannelNumberMatchingName, w.ChannelIndex, w.Presamples, w.Samples,
-		w.FramesPerSample, w.SubframeDivisions,
-		timestamp, starttime, firstrec, w.SubframeOffset,
+		w.ChanName, w.ChannelNumberMatchingName, w.ChannelIndex, w.SubframeDivisions, w.SubframeOffset,
+		w.Presamples, w.Samples, w.FramesPerSample,
+		timestamp, starttime, firstrec,
 		w.PixelXPosition, w.PixelYPosition, w.PixelName, w.Timebase,
 	)
 	_, err := w.writer.WriteString(s)

--- a/ljh/ljh_test.go
+++ b/ljh/ljh_test.go
@@ -49,8 +49,8 @@ func TestRead(t *testing.T) {
 		if pr.TimeCode != tc {
 			t.Errorf("r.NextPulse().TimeCode = %d, want %d", pr.TimeCode, tc)
 		}
-		if pr.RowCount != expectedRC[i] {
-			t.Errorf("r.NextPulse().RowCount = %d, want %d", pr.RowCount, expectedRC[i])
+		if pr.SubframeCount != expectedRC[i] {
+			t.Errorf("r.NextPulse().SubframeCount = %d, want %d", pr.SubframeCount, expectedRC[i])
 		}
 	}
 	_, err = r.NextPulse()
@@ -164,10 +164,10 @@ func TestWriter(t *testing.T) {
 	if record.TimeCode != 127 {
 		t.Errorf("WriterTest, TimeCode Wrong, have %v, wand %v", record.TimeCode, 127)
 	}
-	// WriteRecord accepts a framecount of 8888888 here, but we write the Rowcount 8888888*2+1=17777777
+	// WriteRecord accepts a framecount of 8888888 here, but we write the SubframeCount 8888888*2+1=17777777
 	// w.NumberOfRows = 2, w.RowNum = 1
-	if record.RowCount != 17777777 {
-		t.Errorf("WriterTest, RowCount Wrong, have %v, want %v", record.RowCount, 17777777)
+	if record.SubframeCount != 17777777 {
+		t.Errorf("WriterTest, SubframeCount Wrong, have %v, want %v", record.SubframeCount, 17777777)
 	}
 	w.SourceName = "Lancero"
 	w.WriteHeader(time.Now())

--- a/ljh/ljh_test.go
+++ b/ljh/ljh_test.go
@@ -107,10 +107,11 @@ func TestBadVersionNumbers(t *testing.T) {
 
 func TestWriter(t *testing.T) {
 	w := Writer{FileName: "writertest.ljh",
-		Samples:      100,
-		Presamples:   50,
-		NumberOfRows: 2,
-		RowNum:       1}
+		Samples:           100,
+		Presamples:        50,
+		SubframeDivisions: 2,
+		SubframeOffset:    1,
+	}
 	err := w.CreateFile()
 	if err != nil {
 		t.Errorf("file creation error: %v", err)

--- a/off/off.go
+++ b/off/off.go
@@ -115,11 +115,13 @@ type CreationInfo struct {
 
 // TimeDivisionMultiplexingInfo stores info related to tdm readout for printing to the file header, aids with json formatting
 type TimeDivisionMultiplexingInfo struct {
-	NumberOfRows    int
-	NumberOfColumns int
-	NumberOfChans   int
-	ColumnNum       int
-	RowNum          int
+	NumberOfRows      int
+	NumberOfColumns   int
+	NumberOfChans     int
+	SubframeDivisions int
+	ColumnNum         int
+	RowNum            int
+	SubframeOffset    int
 }
 
 // HeaderWritten returns true if header has been written.

--- a/publish_data.go
+++ b/publish_data.go
@@ -47,13 +47,17 @@ func (dp *DataPublisher) Flush() {
 // SetOFF adds an OFF writer to dp, the .file attribute is nil, and will be instantiated upon next call to dp.WriteRecord
 func (dp *DataPublisher) SetOFF(ChannelIndex int, Presamples int, Samples int, FramesPerSample int,
 	Timebase float64, TimestampOffset time.Time,
-	NumberOfRows, NumberOfColumns, NumberOfChans, rowNum, colNum int,
+	NumberOfRows, NumberOfColumns, NumberOfChans, SubframeDivisions, rowNum, colNum, SubframeOffset int,
 	FileName, sourceName, chanName string, ChannelNumberMatchingName int,
 	Projectors *mat.Dense, Basis *mat.Dense, ModelDescription string, pixel Pixel) {
-	ReadoutInfo := off.TimeDivisionMultiplexingInfo{NumberOfRows: NumberOfRows,
-		NumberOfColumns: NumberOfColumns,
-		NumberOfChans:   NumberOfChans,
-		ColumnNum:       colNum, RowNum: rowNum}
+	ReadoutInfo := off.TimeDivisionMultiplexingInfo{
+		NumberOfRows:      NumberOfRows,
+		NumberOfColumns:   NumberOfColumns,
+		NumberOfChans:     NumberOfChans,
+		SubframeDivisions: SubframeDivisions,
+		ColumnNum:         colNum,
+		RowNum:            rowNum,
+		SubframeOffset:    SubframeOffset}
 	PixelInfo := off.PixelInfo{XPosition: pixel.X, YPosition: pixel.Y, Name: pixel.Name}
 	w := off.NewWriter(FileName, ChannelIndex, chanName, ChannelNumberMatchingName, Presamples, Samples, Timebase,
 		Projectors, Basis, ModelDescription, Build.Version, Build.Githash, sourceName, ReadoutInfo, PixelInfo)

--- a/publish_data.go
+++ b/publish_data.go
@@ -82,12 +82,17 @@ func (dp *DataPublisher) RemoveOFF() {
 
 // SetLJH3 adds an LJH3 writer to dp, the .file attribute is nil, and will be instantiated upon next call to dp.WriteRecord
 func (dp *DataPublisher) SetLJH3(ChannelIndex int, Timebase float64,
-	NumberOfRows int, NumberOfColumns int, FileName string) {
-	w := ljh.Writer3{ChannelIndex: ChannelIndex,
-		Timebase:        Timebase,
-		NumberOfRows:    NumberOfRows,
-		NumberOfColumns: NumberOfColumns,
-		FileName:        FileName}
+	NumberOfRows, NumberOfColumns, SubframeDivisions, SubframeOffset int,
+	FileName string) {
+	w := ljh.Writer3{
+		ChannelIndex:      ChannelIndex,
+		Timebase:          Timebase,
+		NumberOfRows:      NumberOfRows,
+		NumberOfColumns:   NumberOfColumns,
+		SubframeDivisions: SubframeDivisions,
+		SubframeOffset:    SubframeOffset,
+		FileName:          FileName,
+	}
 	dp.LJH3 = &w
 	dp.WritingPaused = false
 	dp.numberWritten = 0
@@ -110,7 +115,7 @@ func (dp *DataPublisher) RemoveLJH3() {
 // SetLJH22 adds an LJH22 writer to dp, the .file attribute is nil, and will be instantiated upon next call to dp.WriteRecord
 func (dp *DataPublisher) SetLJH22(ChannelIndex int, Presamples int, Samples int, FramesPerSample int,
 	Timebase float64, TimestampOffset time.Time,
-	NumberOfRows, NumberOfColumns, NumberOfChans, rowNum, colNum int,
+	NumberOfRows, NumberOfColumns, NumberOfChans, SubframeDivisions, rowNum, colNum, SubframeOffset int,
 	FileName, sourceName, chanName string, ChannelNumberMatchingName int, pixel Pixel) {
 	w := ljh.Writer{ChannelIndex: ChannelIndex,
 		Presamples:                Presamples,
@@ -121,6 +126,7 @@ func (dp *DataPublisher) SetLJH22(ChannelIndex int, Presamples int, Samples int,
 		NumberOfRows:              NumberOfRows,
 		NumberOfColumns:           NumberOfColumns,
 		NumberOfChans:             NumberOfChans,
+		SubframeDivisions:         SubframeDivisions,
 		FileName:                  FileName,
 		DastardVersion:            Build.Version,
 		GitHash:                   Build.Githash,
@@ -129,6 +135,7 @@ func (dp *DataPublisher) SetLJH22(ChannelIndex int, Presamples int, Samples int,
 		SourceName:                sourceName,
 		ColumnNum:                 colNum,
 		RowNum:                    rowNum,
+		SubframeOffset:            SubframeOffset,
 		PixelXPosition:            pixel.X,
 		PixelYPosition:            pixel.Y,
 		PixelName:                 pixel.Name,

--- a/publish_data_test.go
+++ b/publish_data_test.go
@@ -102,7 +102,7 @@ func TestPublishData(t *testing.T) {
 	nsamples := 4
 	projectors := mat.NewDense(nbases, nsamples, make([]float64, nbases*nsamples))
 	basis := mat.NewDense(nsamples, nbases, make([]float64, nbases*nsamples))
-	dp.SetOFF(0, 0, 0, 1, 1, time.Now(), 1, 1, 1, 1, 1, "testData/TestPublishData.off", "sourceName",
+	dp.SetOFF(0, 0, 0, 1, 1, time.Now(), 1, 1, 1, 1, 1, 1, 1, "testData/TestPublishData.off", "sourceName",
 		"chanName", 1, projectors, basis, "ModelDescription", Pixel{})
 	if err := dp.PublishData(records); err != nil {
 		t.Error(err)

--- a/publish_data_test.go
+++ b/publish_data_test.go
@@ -21,7 +21,7 @@ func TestPublishData(t *testing.T) {
 		t.Fail()
 	}
 	startTime := time.Now()
-	dp.SetLJH22(1, 4, len(d), 1, 1, startTime, 8, 1, 16, 3, 0,
+	dp.SetLJH22(1, 4, len(d), 1, 1, startTime, 8, 1, 16, 8, 3, 0, 3,
 		"testData/TestPublishData.ljh", "testSource", "chanX", 1, Pixel{})
 	if err := dp.PublishData(records); err != nil {
 		t.Fail()
@@ -77,7 +77,7 @@ func TestPublishData(t *testing.T) {
 		t.Error("HasPubSummaries() true, want false")
 	}
 
-	dp.SetLJH3(0, 0, 0, 0, "testData/TestPublishData.ljh3")
+	dp.SetLJH3(0, 0, 0, 0, 0, 0, "testData/TestPublishData.ljh3")
 	if err := dp.PublishData(records); err != nil {
 		t.Error("failed to publish record")
 	}
@@ -209,14 +209,14 @@ func BenchmarkPublish(b *testing.B) {
 	})
 	b.Run("PubLJH22", func(b *testing.B) {
 		dp := DataPublisher{}
-		dp.SetLJH22(0, 0, len(d), 1, 0, startTime, 0, 0, 0, 0, 0,
+		dp.SetLJH22(0, 0, len(d), 1, 0, startTime, 0, 0, 0, 0, 0, 0, 0,
 			"TestPublishData.ljh", "testSource", "chanX", 1, Pixel{})
 		defer dp.RemoveLJH22()
 		slowPart(b, dp, records)
 	})
 	b.Run("PubLJH3", func(b *testing.B) {
 		dp := DataPublisher{}
-		dp.SetLJH3(0, 0, 0, 0, "testData/TestPublishData.ljh3")
+		dp.SetLJH3(0, 0, 0, 0, 0, 0, "testData/TestPublishData.ljh3")
 		defer dp.RemoveLJH3()
 		slowPart(b, dp, records)
 	})
@@ -226,10 +226,10 @@ func BenchmarkPublish(b *testing.B) {
 		defer dp.RemovePubRecords()
 		dp.SetPubSummaries()
 		defer dp.RemovePubSummaries()
-		dp.SetLJH22(0, 0, len(d), 1, 0, startTime, 0, 0, 0, 0, 0,
+		dp.SetLJH22(0, 0, len(d), 1, 0, startTime, 0, 0, 0, 0, 0, 0, 0,
 			"testData/TestPublishData.ljh", "testSource", "chanX", 1, Pixel{})
 		defer dp.RemoveLJH22()
-		dp.SetLJH3(0, 0, 0, 0, "testData/TestPublishData.ljh3")
+		dp.SetLJH3(0, 0, 0, 0, 0, 0, "testData/TestPublishData.ljh3")
 		defer dp.RemoveLJH3()
 		slowPart(b, dp, records)
 	})

--- a/roach.go
+++ b/roach.go
@@ -377,6 +377,7 @@ func (rs *RoachSource) PrepareChannels() error {
 	// Number channels starting at zero.
 	rs.chanNames = make([]string, 0, rs.nchan)
 	rs.chanNumbers = make([]int, 0, rs.nchan)
+	rs.subframeOffsets = make([]int, rs.nchan) // All zero for Roach source
 	rs.rowColCodes = make([]RowColCode, 0, rs.nchan)
 	rs.groupKeysSorted = make([]GroupIndex, 0)
 	ncol := 1

--- a/simulated_data_sources.go
+++ b/simulated_data_sources.go
@@ -174,6 +174,8 @@ func (sps *SimPulseSource) Configure(config *SimPulseSourceConfig) error {
 	sps.nchan = config.Nchan
 	sps.sampleRate = config.SampleRate
 	sps.samplePeriod = time.Duration(roundint(1e9 / sps.sampleRate))
+	// As a simple test of LJH file-writing rules, give non-trivial subframe divisions
+	sps.subframeDivisions = sps.nchan
 
 	nsizes := len(config.Amplitudes)
 	sps.cycleLen = nsizes * config.Nsamp
@@ -220,6 +222,10 @@ func (sps *SimPulseSource) Sample() error {
 
 // StartRun launches the repeated loop that generates Triangle data.
 func (sps *SimPulseSource) StartRun() error {
+	// As a quick test of LJH files, give non-trivial subframe offsets
+	for i := 0; i < sps.nchan; i++ {
+		sps.subframeOffsets[i] = i
+	}
 	go func() {
 		log.Printf("starting SimPulseSource with cycleLen %v, nchan %v, timeperbuf %v\n",
 			sps.cycleLen, sps.nchan, sps.timeperbuf)


### PR DESCRIPTION
Add two new fields to the LJH and OFF file headers: "Subframe offset" and "Subframe divisions" to describe the timing of this channel w.r.t. the overall frame clock. Expect offset=row number for Lancero source and =0 for all other sources; subframe divisions = number of rows for Lancero and arbitrary for all other sources (but must match how external triggers are timed).
Throughout code base, update the vocabulary (comments, variable names, function names) to reflect the new usage.
Fixes #337.