### PR TITLE
Nice terminal, without tons of meaningless/debug text

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,8 +1,9 @@
 ## DASTARD Versions
 
-**0.3.2** February 2024-
+**0.3.2** February 9, 2024
 * Make external trigger resolution 64x finer (issue 335).
 * Add subframe info to LJH and OFF headers; use subframe language throughout code (issue 337).
+* Save client msg to ~/.dastard/logs/updates.log (not terminal); cute ASCII bouncer at terminal (issue 338).
 
 **0.3.1** February 3, 2024
 * Add configuration to invert an arbitrary subset of Abaco channels (issue 330).

--- a/client_updater.go
+++ b/client_updater.go
@@ -56,7 +56,7 @@ func publish(pubSocket *zmq4.Socket, update ClientUpdate, message []byte) {
 		return
 	}
 	if _, ok := nologMessages[tag]; !ok {
-		log.Printf("SEND %v %v\n\tmessage body: %v\n", tag, updateType, string(message))
+		UpdateLogger.Printf("SEND %v %v\n-> message body: %v\n", tag, updateType, string(message))
 	}
 	// Send the 2-part message to all subscribers (clients).
 	// If there are errors, retry up to `maxSendAttempts` times with a sleep between.

--- a/cmd/dastard/dastard.go
+++ b/cmd/dastard/dastard.go
@@ -112,7 +112,8 @@ func main() {
 		fmt.Printf("Running on %d CPUs.\n", runtime.NumCPU())
 		os.Exit(0)
 	}
-	fmt.Printf("\nThis is DASTARD version %s (git commit %s)\n", dastard.Build.Version, githash)
+	banner := fmt.Sprintf("\nThis is DASTARD version %s (git commit %s)\n", dastard.Build.Version, githash)
+	fmt.Print(banner)
 
 	if *cpuprofile != "" {
 		f, err := os.Create(*cpuprofile)
@@ -136,6 +137,7 @@ func main() {
 	dastard.UpdateLogger = startLogger(logname)
 	fmt.Printf("Logging problems       to %s\n", problemname)
 	fmt.Printf("Logging client updates to %s\n\n", logname)
+	dastard.UpdateLogger.Printf("\n\n\n\n%s", banner)
 
 	// Find config file, creating it if needed, and read it.
 	if err := setupViper(); err != nil {

--- a/global_config.go
+++ b/global_config.go
@@ -46,10 +46,14 @@ var DastardStartTime time.Time
 // ProblemLogger will log warning messages to a file
 var ProblemLogger *log.Logger
 
+// UpdateLogger will log client updates to a file
+var UpdateLogger *log.Logger
+
 func init() {
 	setPortnumbers(5500)
 	DastardStartTime = time.Now()
 
 	// Dastard main program will override this, but at least initialize with a sensible value
 	ProblemLogger = log.New(os.Stderr, "", log.LstdFlags)
+	UpdateLogger = log.New(os.Stdout, "", log.LstdFlags)
 }

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -105,53 +105,53 @@ func (s *SourceControl) Multiply(args *FactorArgs, reply *int) error {
 
 // ConfigureTriangleSource configures the source of simulated pulses.
 func (s *SourceControl) ConfigureTriangleSource(args *TriangleSourceConfig, reply *bool) error {
-	log.Printf("ConfigureTriangleSource: %d chan, rate=%.3f\n", args.Nchan, args.SampleRate)
+	UpdateLogger.Printf("ConfigureTriangleSource: %d chan, rate=%.3f\n", args.Nchan, args.SampleRate)
 	err := s.triangle.Configure(args)
 	s.clientUpdates <- ClientUpdate{"TRIANGLE", args}
 	*reply = (err == nil)
-	log.Printf("Result is okay=%t and state={%d chan, rate=%.3f}\n", *reply, s.triangle.nchan, s.triangle.sampleRate)
+	UpdateLogger.Printf("Result is okay=%t and state={%d chan, rate=%.3f}\n", *reply, s.triangle.nchan, s.triangle.sampleRate)
 	return err
 }
 
 // ConfigureSimPulseSource configures the source of simulated pulses.
 func (s *SourceControl) ConfigureSimPulseSource(args *SimPulseSourceConfig, reply *bool) error {
-	log.Printf("ConfigureSimPulseSource: %d chan, rate=%.3f\n", args.Nchan, args.SampleRate)
+	UpdateLogger.Printf("ConfigureSimPulseSource: %d chan, rate=%.3f\n", args.Nchan, args.SampleRate)
 	err := s.simPulses.Configure(args)
 	s.clientUpdates <- ClientUpdate{"SIMPULSE", args}
 	*reply = (err == nil)
-	log.Printf("Result is okay=%t and state={%d chan, rate=%.3f}\n", *reply, s.simPulses.nchan, s.simPulses.sampleRate)
+	UpdateLogger.Printf("Result is okay=%t and state={%d chan, rate=%.3f}\n", *reply, s.simPulses.nchan, s.simPulses.sampleRate)
 	return err
 }
 
 // ConfigureLanceroSource configures the lancero cards.
 func (s *SourceControl) ConfigureLanceroSource(args *LanceroSourceConfig, reply *bool) error {
-	log.Printf("ConfigureLanceroSource: mask 0x%4.4x  active cards: %v\n", args.FiberMask, args.ActiveCards)
+	UpdateLogger.Printf("ConfigureLanceroSource: mask 0x%4.4x  active cards: %v\n", args.FiberMask, args.ActiveCards)
 	err := s.lancero.Configure(args)
 	// Remember any errors for later, when we try to start the source.
 	s.lancero.configError = err
 	s.clientUpdates <- ClientUpdate{"LANCERO", args}
 	*reply = (err == nil)
-	log.Printf("Result is okay=%t and state={%d MHz clock, %d cards}\n", *reply, s.lancero.clockMHz, s.lancero.ncards)
+	UpdateLogger.Printf("Result is okay=%t and state={%d MHz clock, %d cards}\n", *reply, s.lancero.clockMHz, s.lancero.ncards)
 	return err
 }
 
 // ConfigureAbacoSource configures the Abaco cards.
 func (s *SourceControl) ConfigureAbacoSource(args *AbacoSourceConfig, reply *bool) error {
-	log.Printf("ConfigureAbacoSource: \n")
+	UpdateLogger.Printf("ConfigureAbacoSource: \n")
 	err := s.abaco.Configure(args)
 	s.clientUpdates <- ClientUpdate{"ABACO", args}
 	*reply = (err == nil)
-	log.Printf("Result is okay=%t\n", *reply)
+	UpdateLogger.Printf("Result is okay=%t\n", *reply)
 	return err
 }
 
 // ConfigureRoachSource configures the abaco cards.
 func (s *SourceControl) ConfigureRoachSource(args *RoachSourceConfig, reply *bool) error {
-	log.Printf("ConfigureRoachSource: \n")
+	UpdateLogger.Printf("ConfigureRoachSource: \n")
 	err := s.roach.Configure(args)
 	s.clientUpdates <- ClientUpdate{"ROACH", args}
 	*reply = (err == nil)
-	log.Printf("Result is okay=%t\n", *reply)
+	UpdateLogger.Printf("Result is okay=%t\n", *reply)
 	return err
 }
 
@@ -204,7 +204,7 @@ func (s *SourceControl) ConfigureTriggers(state *FullTriggerState, reply *bool) 
 		}
 		state.TriggerState.EMTState = newEMTState
 	}
-	log.Printf("Got ConfigureTriggers: %v", spew.Sdump(state))
+	UpdateLogger.Printf("Got ConfigureTriggers: %v", spew.Sdump(state))
 	f := func() {
 		err := s.ActiveSource.ChangeTriggerState(state)
 		s.broadcastTriggerState()
@@ -262,7 +262,7 @@ type SizeObject struct {
 // ConfigurePulseLengths is the RPC-callable service to change pulse record sizes.
 func (s *SourceControl) ConfigurePulseLengths(sizes SizeObject, reply *bool) error {
 	*reply = false // handle the case that sizes fails the validation tests and we return early
-	log.Printf("ConfigurePulseLengths: %d samples (%d pre)\n", sizes.Nsamp, sizes.Npre)
+	UpdateLogger.Printf("ConfigurePulseLengths: %d samples (%d pre)\n", sizes.Nsamp, sizes.Npre)
 	if !s.isSourceActive {
 		return fmt.Errorf("no source is active")
 	}
@@ -640,7 +640,6 @@ func (s *SourceControl) broadcastMixState(mix []float64) {
 func (s *SourceControl) broadcastChannelNames() {
 	if s.isSourceActive && s.status.Running {
 		configs := s.ActiveSource.ChannelNames()
-		// log.Printf("chanNames: %v\n", configs)
 		s.clientUpdates <- ClientUpdate{"CHANNELNAMES", configs}
 	}
 }
@@ -715,7 +714,7 @@ func RunRPCServer(portrpc int, block bool) {
 	var okay bool
 	var spc SimPulseSourceConfig
 	spc.SampleRate = 1000.0
-	log.Printf("Dastard is using config file %s\n", viper.ConfigFileUsed())
+	log.Printf("Dastard config file: %s\n", viper.ConfigFileUsed())
 	err = viper.UnmarshalKey("simpulse", &spc)
 	if spc.Nchan == 0 { // default to a valid Nchan value to avoid ConfigureSimPulseSource throwing an error
 		spc.Nchan = 1
@@ -821,7 +820,7 @@ func RunRPCServer(portrpc int, block bool) {
 			if conn, err := listener.Accept(); err != nil {
 				panic("accept error: " + err.Error())
 			} else {
-				log.Printf("new connection established\n")
+				log.Printf("New client connection established\n")
 				go func() { // this is equivalent to ServeCodec, except all requests from a single connection
 					// are handled SYNCHRONOUSLY, so sourceControl doesn't need a lock
 					// requests from multiple connections are still asynchronous, but we could add slice of

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -900,4 +900,6 @@ func RunRPCServer(portrpc int, block bool) {
 	<-interruptCatcher
 	dummy := "dummy"
 	sourceControl.Stop(&dummy, &okay)
+	// Recover from the AsciiBouncer repeatedly repainting the terminal by printing a newline
+	fmt.Println()
 }


### PR DESCRIPTION
Instead, save the client messages to `~/.dastard/logs/updates.log` and put a cute "I'm still alive" ASCII bouncing text thing at the terminal. Only minimal terminal messages are printed now.