### PR TITLE
Responsive publisher, with asynchronous IO

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,7 +39,7 @@ jobs:
       run: make build && ls -l
 
     - name: Test
-      run: go test -v ./...
+      run: go test -timeout 30s -v ./...
 
     - name: Publish GitHub Release Artifacts
       if: github.event_name == 'release' && github.event.action == 'created'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,13 +19,13 @@ jobs:
         go-version: [ '1.17', 'stable' ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install deps (can we eliminate libsodium?)
       run: sudo apt-get install -y libsodium-dev libzmq3-dev
 
     - name: Setup Go ${{ matrix.go-version }}
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
         cache: true

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 ## DASTARD Versions
 
+**0.3.3** May 2024-
+* Make publisher more responsive: don't block data processors waiting on disk flush.
+
 **0.3.2** February 9, 2024
 * Make external trigger resolution 64x finer (issue 335).
 * Add subframe info to LJH and OFF headers; use subframe language throughout code (issue 337).

--- a/asyncbufio/asyncbufio.go
+++ b/asyncbufio/asyncbufio.go
@@ -1,0 +1,92 @@
+package asyncbufio
+
+import (
+	"bufio"
+	"io"
+	"sync"
+	"time"
+)
+
+// Writer provides asynchronous writing to an underlying io.Writer using buffered channels.
+type Writer struct {
+	writer        *bufio.Writer  // Buffered writer: this does the writing
+	flushNow      chan struct{}  // Channel to signal the underlying writer to flush itself
+	databuffer    chan []byte    // Channel to hold data before writing it
+	flushInterval time.Duration  // Interval for flushing the writer periodically
+	wg            sync.WaitGroup // WaitGroup to synchronize end of writing
+}
+
+// NewWriter creates a new Writer instance.
+func NewWriter(w io.Writer, bufferSize int, flushInterval time.Duration) *Writer {
+	aw := &Writer{
+		writer:        bufio.NewWriter(w),
+		databuffer:    make(chan []byte, bufferSize),
+		flushNow:      make(chan struct{}),
+		flushInterval: flushInterval, // Set the flush interval
+	}
+
+	aw.wg.Add(1)
+	go aw.writeLoop()
+	return aw
+}
+
+// Write stores data to the Writer's buffer for later writing.
+func (aw *Writer) Write(p []byte) (int, error) {
+	select {
+	case aw.databuffer <- p:
+		return len(p), nil
+	default:
+		return 0, io.ErrShortWrite // Return an error if buffer is full
+	}
+}
+
+// Flush flushes any remaining data in the buffer to the underlying writer.
+func (aw *Writer) Flush() error {
+	aw.flushNow <- struct{}{}
+	return nil
+}
+
+// Close closes the Writer, flushing remaining data and waiting for the writeLoop to finish.
+// It is possible to cause a panic by calling Write(p) or Flush() after Close()--we don't
+// test for that case.
+func (aw *Writer) Close() {
+	close(aw.flushNow) // Closing the flushNow channel signals the writeLoop to exit
+	aw.wg.Wait()       // Wait until writing is complete
+}
+
+// writeLoop is a goroutine that continuously moves data from the buffer to the writer.
+func (aw *Writer) writeLoop() {
+	defer aw.wg.Done() // Decrement WaitGroup when writing is complete
+
+	ticker := time.NewTicker(aw.flushInterval) // Ticker to flush periodically
+	defer ticker.Stop()                        // Stop the ticker when the writeLoop exits
+
+	for {
+		breakFromLoop := false
+		select {
+		case data := <-aw.databuffer:
+			aw.writer.Write(data) // Write data from the buffer to the writer
+
+		case _, ok := <-aw.flushNow:
+			breakFromLoop = !ok
+			aw.flush()
+		case <-ticker.C:
+			aw.flush()
+		}
+		if breakFromLoop {
+			return
+		}
+	}
+}
+
+func (aw *Writer) flush() {
+	defer aw.writer.Flush()
+	for {
+		select {
+		case data := <-aw.databuffer:
+			aw.writer.Write(data)
+		default:
+			return
+		}
+	}
+}

--- a/asyncbufio/asyncbufio.go
+++ b/asyncbufio/asyncbufio.go
@@ -11,15 +11,15 @@ type Writer struct {
 	writer        *bufio.Writer // Buffered writer: this does the writing
 	flushNow      chan struct{} // Channel to signal the underlying writer to flush itself
 	flushComplete chan struct{} // Channel to signal underlying writer flush is complete
-	databuffer    chan []byte   // Channel to hold data before writing it
+	datachannel   chan []byte   // Channel to hold data before writing it
 	flushInterval time.Duration // Interval for flushing the writer periodically
 }
 
 // NewWriter creates a new Writer instance.
-func NewWriter(w io.Writer, bufferSize int, flushInterval time.Duration) *Writer {
+func NewWriter(w io.Writer, channelDepth int, flushInterval time.Duration) *Writer {
 	aw := &Writer{
 		writer:        bufio.NewWriter(w),
-		databuffer:    make(chan []byte, bufferSize),
+		datachannel:   make(chan []byte, channelDepth),
 		flushNow:      make(chan struct{}),
 		flushComplete: make(chan struct{}),
 		flushInterval: flushInterval, // Set the flush interval
@@ -29,22 +29,22 @@ func NewWriter(w io.Writer, bufferSize int, flushInterval time.Duration) *Writer
 	return aw
 }
 
-// Write stores data to the Writer's buffer for later writing.
+// Write sends data to the Writer's channel, storing it for later writing.
 func (aw *Writer) Write(p []byte) (int, error) {
 	select {
-	case aw.databuffer <- p:
+	case aw.datachannel <- p:
 		return len(p), nil
 	default:
-		return 0, io.ErrShortWrite // Return an error if buffer is full
+		return 0, io.ErrShortWrite // Return an error if channel is full
 	}
 }
 
-// WriteString writes a string to the buffer for later writing (with an annoying copy--sorry!)
+// WriteString sends a string to the channel for later writing (with an annoying copy--sorry!)
 func (aw *Writer) WriteString(s string) (int, error) {
 	return aw.Write([]byte(s))
 }
 
-// Flush flushes any remaining data in the buffer to the underlying writer.
+// Flush flushes any remaining data in the channel to the underlying writer.
 // Blocks until the flush is complete.
 func (aw *Writer) Flush() error {
 	aw.flushNow <- struct{}{}
@@ -53,22 +53,22 @@ func (aw *Writer) Flush() error {
 }
 
 // Close closes the Writer, flushing remaining data and waiting for the writeLoop to finish.
-// It is possible to cause a panic by calling Write(p) or Flush() after Close()--we don't
+// It will cause a panic to call Write(p) or Flush() after Close()--we don't
 // test for that case.
 func (aw *Writer) Close() {
 	close(aw.flushNow) // Closing the flushNow channel signals the writeLoop to exit
 	<-aw.flushComplete // Wait until writing is complete
 }
 
-// writeLoop is a goroutine that continuously moves data from the buffer to the writer.
+// writeLoop is a goroutine that continuously moves data from the channel to the writer.
 func (aw *Writer) writeLoop() {
 	ticker := time.NewTicker(aw.flushInterval) // Ticker to flush periodically
 	defer ticker.Stop()                        // Stop the ticker when the writeLoop exits
 
 	for {
 		select {
-		case data := <-aw.databuffer:
-			aw.writer.Write(data) // Write data from the buffer to the writer
+		case data := <-aw.datachannel:
+			aw.writer.Write(data) // Write data from the channel to the writer
 
 		case _, ok := <-aw.flushNow:
 			aw.flush()
@@ -85,11 +85,11 @@ func (aw *Writer) writeLoop() {
 }
 
 func (aw *Writer) flush() {
-	// This loop empties the aw.databuffer channel before finally
+	// This loop empties the aw.datachannel channel before finally
 	// calling the underlying writer's Flush() method
 	for {
 		select {
-		case data := <-aw.databuffer:
+		case data := <-aw.datachannel:
 			aw.writer.Write(data)
 		default:
 			aw.writer.Flush()

--- a/asyncbufio/asyncbufio.go
+++ b/asyncbufio/asyncbufio.go
@@ -11,9 +11,10 @@ import (
 type Writer struct {
 	writer        *bufio.Writer  // Buffered writer: this does the writing
 	flushNow      chan struct{}  // Channel to signal the underlying writer to flush itself
+	flushComplete chan struct{}  // Channel to signal underlying writer flush is complete
 	databuffer    chan []byte    // Channel to hold data before writing it
 	flushInterval time.Duration  // Interval for flushing the writer periodically
-	wg            sync.WaitGroup // WaitGroup to synchronize end of writing
+	doneWriting   sync.WaitGroup // WaitGroup to synchronize end of writing
 }
 
 // NewWriter creates a new Writer instance.
@@ -22,10 +23,11 @@ func NewWriter(w io.Writer, bufferSize int, flushInterval time.Duration) *Writer
 		writer:        bufio.NewWriter(w),
 		databuffer:    make(chan []byte, bufferSize),
 		flushNow:      make(chan struct{}),
+		flushComplete: make(chan struct{}),
 		flushInterval: flushInterval, // Set the flush interval
 	}
 
-	aw.wg.Add(1)
+	aw.doneWriting.Add(1)
 	go aw.writeLoop()
 	return aw
 }
@@ -41,8 +43,10 @@ func (aw *Writer) Write(p []byte) (int, error) {
 }
 
 // Flush flushes any remaining data in the buffer to the underlying writer.
+// Blocks until the flush is complete.
 func (aw *Writer) Flush() error {
 	aw.flushNow <- struct{}{}
+	<-aw.flushComplete
 	return nil
 }
 
@@ -50,13 +54,13 @@ func (aw *Writer) Flush() error {
 // It is possible to cause a panic by calling Write(p) or Flush() after Close()--we don't
 // test for that case.
 func (aw *Writer) Close() {
-	close(aw.flushNow) // Closing the flushNow channel signals the writeLoop to exit
-	aw.wg.Wait()       // Wait until writing is complete
+	close(aw.flushNow)    // Closing the flushNow channel signals the writeLoop to exit
+	aw.doneWriting.Wait() // Wait until writing is complete
 }
 
 // writeLoop is a goroutine that continuously moves data from the buffer to the writer.
 func (aw *Writer) writeLoop() {
-	defer aw.wg.Done() // Decrement WaitGroup when writing is complete
+	defer aw.doneWriting.Done() // Decrement WaitGroup when writing is complete
 
 	ticker := time.NewTicker(aw.flushInterval) // Ticker to flush periodically
 	defer ticker.Stop()                        // Stop the ticker when the writeLoop exits
@@ -70,6 +74,9 @@ func (aw *Writer) writeLoop() {
 		case _, ok := <-aw.flushNow:
 			breakFromLoop = !ok
 			aw.flush()
+			// Signal whoever requested this that flushing is done
+			aw.flushComplete <- struct{}{}
+
 		case <-ticker.C:
 			aw.flush()
 		}
@@ -80,12 +87,14 @@ func (aw *Writer) writeLoop() {
 }
 
 func (aw *Writer) flush() {
-	defer aw.writer.Flush()
+	// This loop empties the aw.databuffer channel before finally
+	// calling the underlying writer's Flush() method
 	for {
 		select {
 		case data := <-aw.databuffer:
 			aw.writer.Write(data)
 		default:
+			aw.writer.Flush()
 			return
 		}
 	}

--- a/asyncbufio/asyncbufio.go
+++ b/asyncbufio/asyncbufio.go
@@ -42,6 +42,11 @@ func (aw *Writer) Write(p []byte) (int, error) {
 	}
 }
 
+// WriteString writes a string to the buffer for later writing (with an annoying copy--sorry!)
+func (aw *Writer) WriteString(s string) (int, error) {
+	return aw.Write([]byte(s))
+}
+
 // Flush flushes any remaining data in the buffer to the underlying writer.
 // Blocks until the flush is complete.
 func (aw *Writer) Flush() error {

--- a/asyncbufio/asyncbufio_test.go
+++ b/asyncbufio/asyncbufio_test.go
@@ -1,0 +1,72 @@
+package asyncbufio
+
+import (
+	"crypto/md5"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"testing"
+	"time"
+)
+
+func md5sum(fname string) string {
+	f, err := os.Open(fname)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+
+	h := md5.New()
+	if _, err := io.Copy(h, f); err != nil {
+		log.Fatal(err)
+	}
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+func TestWrite(t *testing.T) {
+	f, err := os.CreateTemp("", "example")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.Remove(f.Name()) // clean up
+
+	w := NewWriter(f, 100, time.Second)
+	for i := 0; i < 100; i++ {
+		sometext := []byte(fmt.Sprintf("Line of text %3d\n", i))
+		w.Write(sometext)
+		if i%25 == 19 {
+			w.Flush()
+		}
+	}
+	w.Write([]byte("Last line\n"))
+	w.Close()
+
+	// Verify exact file contents
+	actual := md5sum(f.Name())
+	expected := "49c3d3dc6d2929a997016c9509010333"
+	if actual != expected {
+		t.Errorf("example file md5=%s, want %s", actual, expected)
+	}
+
+	// Tricky way to test for an expected panic:
+	defer func() { recover() }()
+	w.Flush()
+	t.Errorf("asyncbufio.Writer.Flush() after .Close() did not panic")
+}
+
+func TestCloseTwice(t *testing.T) {
+	f, err := os.CreateTemp("", "example")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.Remove(f.Name()) // clean up
+
+	w := NewWriter(f, 100, time.Second)
+	w.Close()
+
+	// Tricky way to test for an expected panic:
+	defer func() { recover() }()
+	w.Close()
+	t.Errorf("asyncbufio.Writer.Flush() after .Close() did not panic")
+}

--- a/global_config.go
+++ b/global_config.go
@@ -35,7 +35,7 @@ type BuildInfo struct {
 
 // Build is a global holding compile-time information about the build
 var Build = BuildInfo{
-	Version: "0.3.2",
+	Version: "0.3.3",
 	Githash: "no git hash computed",
 	Date:    "no build date computed",
 }

--- a/ljh/ljh.go
+++ b/ljh/ljh.go
@@ -219,6 +219,9 @@ func (w Writer) Flush() {
 
 // Close closes the associated file, no more records can be written after this
 func (w Writer) Close() {
+	if w.writer != nil {
+		w.writer.Close()
+	}
 	w.file.Close()
 }
 
@@ -344,7 +347,9 @@ func (w Writer3) Flush() {
 
 // Close closes the LJH3 file
 func (w Writer3) Close() {
-	w.Flush()
+	if w.writer != nil {
+		w.writer.Close()
+	}
 	w.file.Close()
 }
 

--- a/ljh/ljh.go
+++ b/ljh/ljh.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/usnistgov/dastard/asyncbufio"
 	"github.com/usnistgov/dastard/getbytes"
 )
 
@@ -76,7 +77,7 @@ type Writer struct {
 	PixelName                 string
 
 	file   *os.File
-	writer *bufio.Writer
+	writer *asyncbufio.Writer
 }
 
 // OpenReader returns an active LJH file reader, or an error.
@@ -146,7 +147,8 @@ func (w *Writer) CreateFile() error {
 	} else {
 		return errors.New("file already exists")
 	}
-	w.writer = bufio.NewWriterSize(w.file, 32768)
+	bw := bufio.NewWriterSize(w.file, 32768)
+	w.writer = asyncbufio.NewWriter(bw, 1000, time.Second)
 	return nil
 }
 
@@ -208,7 +210,6 @@ func (w Writer) Flush() {
 
 // Close closes the associated file, no more records can be written after this
 func (w Writer) Close() {
-	w.Flush()
 	w.file.Close()
 }
 

--- a/off/off.go
+++ b/off/off.go
@@ -212,7 +212,9 @@ func (w Writer) Flush() {
 
 // Close closes the file, it flushes the bufio.Writer first
 func (w Writer) Close() {
-	w.Flush()
+	if w.writer != nil {
+		w.writer.Close()
+	}
 	w.file.Close()
 }
 

--- a/off/off.go
+++ b/off/off.go
@@ -21,9 +21,19 @@ import (
 	"os"
 	"time"
 
+	"github.com/usnistgov/dastard/asyncbufio"
 	"github.com/usnistgov/dastard/getbytes"
 	"gonum.org/v1/gonum/mat"
 )
+
+// The buffer size (bytes) of the bufio.Writer that buffers disk output
+const BUFIOSIZE = 65536
+
+// The capacity of unprocessed pulse records before even the "asynchronous" writes will block.
+const WRITECHANCAPACITY = 1000
+
+// Flush the ouputfile regularly at this interval
+const FLUSHINTERVAL = 3 * time.Second
 
 // Writer writes OFF files
 type Writer struct {
@@ -46,7 +56,7 @@ type Writer struct {
 	fileName       string
 	headerWritten  bool
 	file           *os.File
-	writer         *bufio.Writer
+	writer         *asyncbufio.Writer
 }
 
 // NewWriter creates a new OFF writer. No file is created until the first call to WriteRecord
@@ -218,6 +228,7 @@ func (w *Writer) CreateFile() error {
 	} else {
 		return errors.New("file already exists")
 	}
-	w.writer = bufio.NewWriterSize(w.file, 32768)
+	bw := bufio.NewWriterSize(w.file, BUFIOSIZE)
+	w.writer = asyncbufio.NewWriter(bw, WRITECHANCAPACITY, FLUSHINTERVAL)
 	return nil
 }

--- a/process_data_test.go
+++ b/process_data_test.go
@@ -242,11 +242,11 @@ func testAnalyzeCheck(t *testing.T, rec *DataRecord, expect RTExpect, name strin
 
 func testAnalyzePretrigCheck(t *testing.T, rec *DataRecord, expect RTExpect, name string) {
 	if math.Abs(rec.pretrigMean-expect.pretrigMean) > 1e-7 && !(math.IsNaN(rec.pretrigMean) && math.IsNaN(expect.pretrigMean)) {
-		t.Errorf("Pretrigger mean = %v, want %v", rec.pretrigMean, expect.pretrigMean)
+		t.Errorf("%s: Pretrigger mean = %v, want %v", name, rec.pretrigMean, expect.pretrigMean)
 		t.Logf("%v\n", rec)
 	}
 	if math.Abs(rec.pretrigDelta-expect.pretrigDelta) > 1e-7 && !(math.IsNaN(rec.pretrigDelta) && math.IsNaN(expect.pretrigDelta)) {
-		t.Errorf("Pretrigger delta = %v, want %v", rec.pretrigDelta, expect.pretrigDelta)
+		t.Errorf("%s: Pretrigger delta = %v, want %v", name, rec.pretrigDelta, expect.pretrigDelta)
 		t.Logf("%v\n", rec)
 	}
 }

--- a/roach_test.go
+++ b/roach_test.go
@@ -40,7 +40,7 @@ func newBuffer(nchan, nsamp uint16, sampnum uint64) []byte {
 	return buf.Bytes()
 }
 
-func publishRoachPackets(port int, nchan uint16, value uint16) (closer chan struct{}, err error) {
+func publishRoachPackets(port int, nchan uint16) (closer chan struct{}, err error) {
 
 	host := fmt.Sprintf("127.0.0.1:%d", port)
 	raddr, err := net.ResolveUDPAddr("udp", host)
@@ -77,7 +77,7 @@ func TestRoachDevice(t *testing.T) {
 	// Start generating Roach packets, until closer is closed.
 	port := 60001
 	var nchan uint16 = 40
-	packetSourceCloser, err := publishRoachPackets(port, nchan, 0xbeef)
+	packetSourceCloser, err := publishRoachPackets(port, nchan)
 	defer close(packetSourceCloser)
 	if err != nil {
 		t.Errorf("publishRoachPackets returned %v", err)
@@ -132,7 +132,7 @@ func TestRoachSource(t *testing.T) {
 	// Start generating Roach packets, until closer is closed.
 	port := 60005
 	var nchan uint16 = 40
-	packetSourceCloser, err := publishRoachPackets(port, nchan, 0xbeef)
+	packetSourceCloser, err := publishRoachPackets(port, nchan)
 	defer close(packetSourceCloser)
 
 	if err != nil {


### PR DESCRIPTION
Try to solve problems with slow disk access by inserting a deep channel for `[]byte` objects between the publisher in Go and an underlying `bufio.Writer` object.

We saw problems with slow disk writing in the HausKat project, but we hope this leads to better performance in general.