### PR TITLE
`WritingState` object says which file types are written

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -2,6 +2,7 @@
 
 **0.3.4** May 2024-
 * Update all package dependencies (issue 347).
+* Send which types of files are active in the report about writing data (issue 343).
 
 **0.3.3** May 28, 2024
 * Make publisher more responsive: don't block data processors waiting on disk flush.

--- a/data_source.go
+++ b/data_source.go
@@ -645,8 +645,8 @@ func makeDirectory(basepath string) (string, error) {
 }
 
 // WriteControl changes the data writing start/stop/pause/unpause state
-// For WriteLJH22 == true and/or WriteLJH3 == true all channels will have writing enabled
-// For WriteOFF == true, only chanels with projectors set will have writing enabled
+// For (WriteLJH22 == true) and/or (WriteLJH3 == true), all channels will have writing enabled
+// For (WriteOFF == true), only chanels with projectors set will have writing enabled
 func (ds *AnySource) WriteControl(config *WriteControlConfig) error {
 	requestStr := strings.ToUpper(config.Request)
 	switch {
@@ -773,7 +773,7 @@ func (ds *AnySource) writeControlStart(config *WriteControlConfig) error {
 				ds.subframeOffsets[i], filename)
 		}
 	}
-	return ds.writingState.Start(filenamePattern, path)
+	return ds.writingState.Start(filenamePattern, path, config)
 }
 
 // ComputeWritingState returns a partial copy of the writingState

--- a/global_config.go
+++ b/global_config.go
@@ -35,7 +35,7 @@ type BuildInfo struct {
 
 // Build is a global holding compile-time information about the build
 var Build = BuildInfo{
-	Version: "0.3.4pre1",
+	Version: "0.3.4pre2",
 	Githash: "no git hash computed",
 	Date:    "no build date computed",
 }

--- a/writing_state.go
+++ b/writing_state.go
@@ -14,6 +14,9 @@ type WritingState struct {
 	Paused                            bool
 	BasePath                          string
 	FilenamePattern                   string
+	WriteLJH22                        bool // which file formats are active
+	WriteOFF                          bool
+	WriteLJH3                         bool
 	experimentStateFile               *os.File
 	ExperimentStateFilename           string
 	ExperimentStateLabel              string
@@ -54,16 +57,22 @@ func (ws *WritingState) ComputeState() *WritingState {
 	copyState.ExperimentStateLabelUnixNano = ws.ExperimentStateLabelUnixNano
 	copyState.ExternalTriggerFilename = ws.ExternalTriggerFilename
 	copyState.externalTriggerNumberObserved = ws.externalTriggerNumberObserved
+	copyState.WriteLJH22 = ws.WriteLJH22
+	copyState.WriteLJH3 = ws.WriteLJH3
+	copyState.WriteOFF = ws.WriteOFF
 	return &copyState
 }
 
 // Start will set the WritingState to begin writing
-func (ws *WritingState) Start(filenamePattern, path string) error {
+func (ws *WritingState) Start(filenamePattern, path string, config *WriteControlConfig) error {
 	ws.Lock()
 	defer ws.Unlock()
 	ws.Active = true
 	ws.Paused = false
 	ws.BasePath = path
+	ws.WriteLJH22 = config.WriteLJH22
+	ws.WriteLJH3 = config.WriteLJH3
+	ws.WriteOFF = config.WriteOFF
 	ws.FilenamePattern = filenamePattern
 	ws.ExperimentStateFilename = fmt.Sprintf(filenamePattern, "experiment_state", "txt")
 	ws.ExternalTriggerFilename = fmt.Sprintf(filenamePattern, "external_trigger", "bin")


### PR DESCRIPTION
Fixes #343. Dastard Commander needs this to fix [its issue 146](https://github.com/usnistgov/dastardcommander/issues/146). This distributes the info about whether any or all of the following files are being written:
- LJH22
- LJH3
- OFF
