### PR TITLE
Fix ambiguous Makefile variable name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,12 @@ NETGO=-tags netgo
 .PHONY: all build install test clean run deps static
 
 GLOBALVARIABLES=-X main.buildDate=$(shell date -u '+%Y-%m-%d.%H:%M:%S.%Z') -X main.githash=$(shell git rev-parse --short HEAD)
-LDFLAGS=-ldflags "$(GLOBALVARIABLES)"
+GOLINKFLAGS=-ldflags "$(GLOBALVARIABLES)"
 build: $(BINARY_NAME)
 all: test build install
 
 $(BINARY_NAME): Makefile *.go cmd/dastard/dastard.go */*.go
-	$(GOBUILD) $(LDFLAGS) $(NETGO) -o $(BINARY_NAME) cmd/dastard/dastard.go
+	$(GOBUILD) $(GOLINKFLAGS) $(NETGO) -o $(BINARY_NAME) cmd/dastard/dastard.go
 
 test:
 	$(GOFMT)

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -3,6 +3,7 @@
 **0.3.4** May 2024-
 * Update all package dependencies (issue 347).
 * Send which types of files are active in the report about writing data (issue 343).
+* Rename bad Makefile variable `LDFLAGS` -> `GOLINKFLAGS` (issue 350).
 
 **0.3.3** May 28, 2024
 * Make publisher more responsive: don't block data processors waiting on disk flush.


### PR DESCRIPTION
Fixes #350. I don't understand `make` well enough to see why it was a problem to use `LDFLAGS` as a Make variable, but I do know that there is a system-controlled and Conda-controlled shell variable by the same name. I was messing up linking by assigning to the Make variable of that name. So I stopped.