### PR TITLE
Don't allow default `Nsamples` or `Npresamples` of 0 to persist

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,9 +1,10 @@
 ## DASTARD Versions
 
-**0.3.4** May 2024-
+**0.3.4** August 23, 2024
 * Update all package dependencies (issue 347).
 * Send which types of files are active in the report about writing data (issue 343).
 * Rename bad Makefile variable `LDFLAGS` -> `GOLINKFLAGS` (issue 350).
+* When no config file exists, set `Nsamples` to a nonzero value, preventing some crashes (issues 355, 356).
 
 **0.3.3** May 28, 2024
 * Make publisher more responsive: don't block data processors waiting on disk flush.

--- a/global_config.go
+++ b/global_config.go
@@ -35,7 +35,7 @@ type BuildInfo struct {
 
 // Build is a global holding compile-time information about the build
 var Build = BuildInfo{
-	Version: "0.3.4pre2",
+	Version: "0.3.4",
 	Githash: "no git hash computed",
 	Date:    "no build date computed",
 }

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -305,15 +305,18 @@ type SizeObject struct {
 // ConfigurePulseLengths is the RPC-callable service to change pulse record sizes.
 func (s *SourceControl) ConfigurePulseLengths(sizes SizeObject, reply *bool) error {
 	*reply = false // handle the case that sizes fails the validation tests and we return early
-	UpdateLogger.Printf("ConfigurePulseLengths: %d samples (%d pre)\n", sizes.Nsamp, sizes.Npre)
 	if !s.isSourceActive {
 		return fmt.Errorf("no source is active")
 	}
+	if sizes.Nsamp <= 0 || sizes.Npre <= 0 {
+		return fmt.Errorf("cannot ConfigurePulseLengths with non-positive values: %v", sizes)
+	}
+	UpdateLogger.Printf("ConfigurePulseLengths: %d samples (%d pre)\n", sizes.Nsamp, sizes.Npre)
 	if s.status.Npresamp == sizes.Npre && s.status.Nsamples == sizes.Nsamp {
 		return nil // no change requested
 	}
 	if s.ActiveSource.WritingIsActive() {
-		return fmt.Errorf("Stop writing before changing record lengths")
+		return fmt.Errorf("stop writing before changing record lengths")
 	}
 
 	f := func() {

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -744,6 +744,10 @@ func (s *SourceControl) StoreRawDataBlock(N int, reply *string) error {
 // (The intention is that block=true in normal operation, but false for certain tests.)
 func RunRPCServer(portrpc int, block bool) {
 	// Set up objects to handle remote calls
+
+	// Set up source control. Later, we will try to use `viper.UnmarshallKey("status"...)' to fill
+	// it with stored values from ~/.dastard/config.yaml. But in the absence of stored values, we
+	// need to set some reasonable defaults, including non-zero values of Nsamples and Npresamples.
 	sourceControl := NewSourceControl()
 	defer sourceControl.lancero.Delete()
 	sourceControl.clientUpdates = clientMessageChan

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -814,6 +814,17 @@ func RunRPCServer(portrpc int, block bool) {
 	}
 
 	err = viper.UnmarshalKey("status", &sourceControl.status)
+	// Set some defaults that won't cause problems down the line.
+	status := &sourceControl.status
+	if status.Npresamp <= 0 {
+		status.Npresamp = 400
+	}
+	if status.Nsamples <= status.Npresamp {
+		status.Nsamples = 2 * status.Npresamp
+	}
+	if status.SamplePeriod <= 0 {
+		status.SamplePeriod = 10 * time.Microsecond
+	}
 	sourceControl.status.Running = false
 	sourceControl.ActiveSource = sourceControl.triangle
 	sourceControl.isSourceActive = false

--- a/rpc_server_test.go
+++ b/rpc_server_test.go
@@ -69,15 +69,6 @@ func TestServer(t *testing.T) {
 	if now := viper.Get("currenttime"); now == nil {
 		t.Errorf("viper.Get(\"currenttime\") returns nil")
 	}
-	sourceControl := NewSourceControl()
-	if err = viper.UnmarshalKey("status", &sourceControl.status); err != nil {
-		t.Errorf("viper.UnmarshalKey(\"status\") returns nil")
-	}
-	if sourceControl.status.Nsamples == 0 {
-		t.Errorf("viper[status] has Nsamples=0")
-	} else if sourceControl.status.Npresamp == 0 {
-		t.Errorf("viper[status] has Npresamples=0")
-	}
 
 	var okay bool
 

--- a/rpc_server_test.go
+++ b/rpc_server_test.go
@@ -399,16 +399,17 @@ func verifyConfigFile(path, filename string) error {
 		}
 	}
 
-	// Create an empty file path/filename, if it doesn't exist.
+	// If it exists, delete it. Then create an empty file path/filename.
 	fullname := filepath.Join(path, filename)
 	_, err = os.Stat(fullname)
-	if os.IsNotExist(err) {
-		f, err := os.OpenFile(fullname, os.O_WRONLY|os.O_CREATE, 0664)
-		if err != nil {
-			return err
-		}
-		f.Close()
+	if !os.IsNotExist(err) {
+		os.Remove(fullname)
 	}
+	f, err := os.OpenFile(fullname, os.O_WRONLY|os.O_CREATE, 0664)
+	if err != nil {
+		return err
+	}
+	f.Close()
 	return nil
 }
 

--- a/rpc_server_test.go
+++ b/rpc_server_test.go
@@ -69,6 +69,15 @@ func TestServer(t *testing.T) {
 	if now := viper.Get("currenttime"); now == nil {
 		t.Errorf("viper.Get(\"currenttime\") returns nil")
 	}
+	sourceControl := NewSourceControl()
+	if err = viper.UnmarshalKey("status", &sourceControl.status); err != nil {
+		t.Errorf("viper.UnmarshalKey(\"status\") returns nil")
+	}
+	if sourceControl.status.Nsamples == 0 {
+		t.Errorf("viper[status] has Nsamples=0")
+	} else if sourceControl.status.Npresamp == 0 {
+		t.Errorf("viper[status] has Npresamples=0")
+	}
 
 	var okay bool
 
@@ -566,6 +575,13 @@ waitingforfile:
 		if data[i] != data[0] {
 			t.Errorf("npz file firstFrameIndex vector not all alike: %v", data)
 		}
+	}
+}
+
+func TestNoConfigFile(t *testing.T) {
+	// Find config file, creating it if needed, and read it.
+	if err := setupViper(); err != nil {
+		panic(err)
 	}
 }
 


### PR DESCRIPTION
When reading the viper settings, it's possible that `Nsamples` and `Npresamples` are not found, and are set to the Golang default integer values of zero. Immediately fix non-positive values after reading.

Unfortunately, I cannot figure out a way to test this automatically, b/c the testing framework doesn't have direct access to the Dastard internals, but instead only talks to a running server. We'd have to connect to and parse the messages to the status-message port. Not worth the trouble, I judge.

Fixes #355. Fixes #356.