### PR TITLE
Fix zero ext trigger times

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 ## DASTARD Versions
 
+**0.3.5** April 22, 2025
+* Fix bug that was writing zeros for the external trigger (issue 362).
+
 **0.3.4** August 23, 2024
 * Update all package dependencies (issue 347).
 * Send which types of files are active in the report about writing data (issue 343).

--- a/abaco.go
+++ b/abaco.go
@@ -134,9 +134,13 @@ func (group *AbacoGroup) updateFrameTiming(p *packets.Packet, frameIdx FrameInde
 	deltaSubframe := newSubframeCount - group.LastSubframeCount
 	deltaTs := ts.T - group.LastFirmwareTimestamp.T
 	// There will be transient nonsense if the timestamp.Rate changes. I think the best
-	// approach is to ignore. After the next (consistent) timestamp, it will recover.
+	// approach is set subframe rate to 0. After the next (consistent) timestamp, it will recover.
+	unequalRates := ts.Rate != group.LastFirmwareTimestamp.Rate
 	group.LastFirmwareTimestamp = *ts
 	group.LastSubframeCount = newSubframeCount
+	if deltaSubframe <= 0 || deltaTs == 0 || unequalRates {
+		return
+	}
 	group.TimestampCountsPerSubframe = deltaTs / uint64(deltaSubframe)
 }
 

--- a/abaco.go
+++ b/abaco.go
@@ -137,11 +137,9 @@ func (group *AbacoGroup) updateFrameTiming(p *packets.Packet, frameIdx FrameInde
 	// approach is to ignore. After the next (consistent) timestamp, it will recover.
 	group.LastFirmwareTimestamp = *ts
 	group.LastSubframeCount = newSubframeCount
-	if deltaSubframe <= 0 || deltaTs == 0 {
-		group.TimestampCountsPerSubframe = 0
-		return
+	if deltaSubframe > 0 {
+		group.TimestampCountsPerSubframe = deltaTs / uint64(deltaSubframe)
 	}
-	group.TimestampCountsPerSubframe = deltaTs / uint64(deltaSubframe)
 }
 
 // subframeCountFromTimestamp uses the group.FrameTimingCorrespondence data to

--- a/abaco.go
+++ b/abaco.go
@@ -13,6 +13,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/fabiokung/shm"
 	"github.com/usnistgov/dastard/packets"
 	"github.com/usnistgov/dastard/ringbuffer"
@@ -134,6 +135,8 @@ func (group *AbacoGroup) updateFrameTiming(p *packets.Packet, frameIdx FrameInde
 	deltaSubframe := newSubframeCount - group.LastSubframeCount
 	deltaTs := ts.T - group.LastFirmwareTimestamp.T
 	if deltaSubframe <= 0 || deltaTs == 0 {
+		spew.Dump(p)
+		spew.Dump(group.LastFirmwareTimestamp)
 		return
 	}
 	// There will be transient nonsense if the timestamp.Rate changes. I think the best

--- a/abaco.go
+++ b/abaco.go
@@ -136,6 +136,7 @@ func (group *AbacoGroup) updateFrameTiming(p *packets.Packet, frameIdx FrameInde
 	deltaTs := ts.T - group.LastFirmwareTimestamp.T
 	spew.Dump(p)
 	spew.Dump(group.LastFirmwareTimestamp)
+	spew.Dump(deltaTs)
 	if deltaSubframe <= 0 || deltaTs == 0 {
 		println("No change in timing. Return without updates.")
 		return

--- a/abaco.go
+++ b/abaco.go
@@ -133,13 +133,14 @@ func (group *AbacoGroup) updateFrameTiming(p *packets.Packet, frameIdx FrameInde
 	newSubframeCount := frameIdx * abacoSubframeDivisions
 	deltaSubframe := newSubframeCount - group.LastSubframeCount
 	deltaTs := ts.T - group.LastFirmwareTimestamp.T
+	if deltaSubframe <= 0 || deltaTs == 0 {
+		return
+	}
 	// There will be transient nonsense if the timestamp.Rate changes. I think the best
-	// approach is to ignore. After the next (consistent) timestamp, it will recover.
+	// approach is set subframe rate to 0. After the next (consistent) timestamp, it will recover.
 	group.LastFirmwareTimestamp = *ts
 	group.LastSubframeCount = newSubframeCount
-	if deltaSubframe > 0 {
-		group.TimestampCountsPerSubframe = deltaTs / uint64(deltaSubframe)
-	}
+	group.TimestampCountsPerSubframe = deltaTs / uint64(deltaSubframe)
 }
 
 // subframeCountFromTimestamp uses the group.FrameTimingCorrespondence data to

--- a/abaco.go
+++ b/abaco.go
@@ -137,7 +137,8 @@ func (group *AbacoGroup) updateFrameTiming(p *packets.Packet, frameIdx FrameInde
 		return
 	}
 	// There will be transient nonsense if the timestamp.Rate changes. I think the best
-	// approach is set subframe rate to 0. After the next (consistent) timestamp, it will recover.
+	// approach is to proceed heedless of the nonsense.
+	// After the next (consistent) timestamp, it will recover.
 	group.LastFirmwareTimestamp = *ts
 	group.LastSubframeCount = newSubframeCount
 	group.TimestampCountsPerSubframe = deltaTs / uint64(deltaSubframe)

--- a/abaco.go
+++ b/abaco.go
@@ -812,6 +812,7 @@ func (as *AbacoSource) Configure(config *AbacoSourceConfig) (err error) {
 
 // distributePackets sorts a slice of Abaco packets into the data queues according to the GroupIndex.
 func (as *AbacoSource) distributePackets(allpackets []*packets.Packet, now time.Time) {
+	frameTimeUpdated := false
 	for _, p := range allpackets {
 		if p.IsExternalTrigger() {
 			as.eTrigPackets = append(as.eTrigPackets, p)
@@ -821,7 +822,10 @@ func (as *AbacoSource) distributePackets(allpackets []*packets.Packet, now time.
 		cidx := gIndex(p)
 		grp := as.groups[cidx]
 		grp.enqueuePacket(p, now)
-		grp.updateFrameTiming(p, as.nextFrameNum)
+		if !frameTimeUpdated {
+			grp.updateFrameTiming(p, as.nextFrameNum)
+			frameTimeUpdated = true
+		}
 	}
 }
 

--- a/abaco.go
+++ b/abaco.go
@@ -134,14 +134,9 @@ func (group *AbacoGroup) updateFrameTiming(p *packets.Packet, frameIdx FrameInde
 	deltaSubframe := newSubframeCount - group.LastSubframeCount
 	deltaTs := ts.T - group.LastFirmwareTimestamp.T
 	// There will be transient nonsense if the timestamp.Rate changes. I think the best
-	// approach is set subframe rate to 0. After the next (consistent) timestamp, it will recover.
-	unequalRates := ts.Rate != group.LastFirmwareTimestamp.Rate
+	// approach is to ignore. After the next (consistent) timestamp, it will recover.
 	group.LastFirmwareTimestamp = *ts
 	group.LastSubframeCount = newSubframeCount
-	if deltaSubframe <= 0 || deltaTs == 0 || unequalRates {
-		group.TimestampCountsPerSubframe = 0
-		return
-	}
 	group.TimestampCountsPerSubframe = deltaTs / uint64(deltaSubframe)
 }
 

--- a/abaco.go
+++ b/abaco.go
@@ -134,11 +134,16 @@ func (group *AbacoGroup) updateFrameTiming(p *packets.Packet, frameIdx FrameInde
 	newSubframeCount := frameIdx * abacoSubframeDivisions
 	deltaSubframe := newSubframeCount - group.LastSubframeCount
 	deltaTs := ts.T - group.LastFirmwareTimestamp.T
+	spew.Dump(p)
+	spew.Dump(group.LastFirmwareTimestamp)
 	if deltaSubframe <= 0 || deltaTs == 0 {
-		spew.Dump(p)
-		spew.Dump(group.LastFirmwareTimestamp)
+		println("No change in timing. Return without updates.")
 		return
 	}
+	println("Change in timing")
+	spew.Dump(ts)
+	spew.Dump(newSubframeCount)
+	spew.Dump(deltaTs)
 	// There will be transient nonsense if the timestamp.Rate changes. I think the best
 	// approach is to proceed heedless of the nonsense.
 	// After the next (consistent) timestamp, it will recover.

--- a/abaco.go
+++ b/abaco.go
@@ -134,11 +134,11 @@ func (group *AbacoGroup) updateFrameTiming(p *packets.Packet, frameIdx FrameInde
 	deltaSubframe := newSubframeCount - group.LastSubframeCount
 	deltaTs := ts.T - group.LastFirmwareTimestamp.T
 	// There will be transient nonsense if the timestamp.Rate changes. I think the best
-	// approach is set subframe rate to 0. After the next (consistent) timestamp, it will recover.
-	unequalRates := ts.Rate != group.LastFirmwareTimestamp.Rate
+	// approach is to ignore. After the next (consistent) timestamp, it will recover.
 	group.LastFirmwareTimestamp = *ts
 	group.LastSubframeCount = newSubframeCount
-	if deltaSubframe <= 0 || deltaTs == 0 || unequalRates {
+	if deltaSubframe <= 0 || deltaTs == 0 {
+		group.TimestampCountsPerSubframe = 0
 		return
 	}
 	group.TimestampCountsPerSubframe = deltaTs / uint64(deltaSubframe)

--- a/global_config.go
+++ b/global_config.go
@@ -35,7 +35,7 @@ type BuildInfo struct {
 
 // Build is a global holding compile-time information about the build
 var Build = BuildInfo{
-	Version: "0.3.4",
+	Version: "0.3.5",
 	Githash: "no git hash computed",
 	Date:    "no build date computed",
 }


### PR DESCRIPTION
Fixes #362. Or, I think it does.

The correct behavior is to ignore packets that don't have an increased value of the subframe counter, when using them for `AbacoGroup.updateFrameTiming(...)`. We were erroneously setting certain values to zero when such (non-increasing) packets were found. Don't understand the firmware behavior enough to know what the cause was, but we do want to skip them for this purpose.