### PR TITLE
There can be only one

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -2,6 +2,7 @@
 
 **0.3.6** May 6, 2025-
 * Make Abaco data be considered unsigned (issue 364).
+* Add feature where EMT retrigger can create one record, not just 0 or 2 records (issue 366).
 
 **0.3.5** April 22, 2025
 * Fix bug that was writing zeros for the external trigger (issue 362).

--- a/edge_multi_test.go
+++ b/edge_multi_test.go
@@ -87,7 +87,14 @@ func TestEdgeMultiParts1(t *testing.T) {
 				nmonotone: 1, npre: 2, nsamp: 4},
 			[]RecordSpec{{firstRisingFrameIndex: 4, npre: 2, nsamp: 4},
 				{firstRisingFrameIndex: 7, npre: 2, nsamp: 4}},
-			"edgeMultiComputeAppendRecordSpecs: 2 records should yield two full-length records",
+			"edgeMultiComputeAppendRecordSpecs: 2 records should yield two full-length records with TwoFullLength",
+		},
+		{
+			[]RawType{0, 0, 0, 0, 10, 20, 0, 10, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			EMTState{threshold: 1, mode: EMTRecordsOneFullLength,
+				nmonotone: 1, npre: 2, nsamp: 4},
+			[]RecordSpec{{firstRisingFrameIndex: 4, npre: 2, nsamp: 4}},
+			"edgeMultiComputeAppendRecordSpecs: 2 records should yield one full-length records with OneFullLength",
 		},
 		{
 			[]RawType{0, 0, 0, 0, 10, 20, 0, 10, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},

--- a/edge_multi_trigger.go
+++ b/edge_multi_trigger.go
@@ -14,6 +14,7 @@ type EMTBackwardCompatibleRPCFields struct {
 	EdgeMultiNoise                   bool
 	EdgeMultiMakeShortRecords        bool
 	EdgeMultiMakeContaminatedRecords bool
+	EdgeMultiMakeSingleRecords       bool
 	EdgeMultiDisableZeroThreshold    bool
 	EdgeMultiLevel                   int32
 	EdgeMultiVerifyNMonotone         int
@@ -34,6 +35,8 @@ func (b EMTBackwardCompatibleRPCFields) toEMTState() (EMTState, error) {
 	}
 	if b.EdgeMultiMakeContaminatedRecords {
 		s.mode = EMTRecordsTwoFullLength
+	} else if b.EdgeMultiMakeSingleRecords {
+		s.mode = EMTRecordsOneFullLength
 	} else if b.EdgeMultiMakeShortRecords {
 		s.mode = EMTRecordsVariableLength
 	} else {

--- a/edge_multi_trigger.go
+++ b/edge_multi_trigger.go
@@ -253,6 +253,7 @@ const (
 	EMTRecordsTwoFullLength      EMTMode = iota // Generate two full-length records even if they overlap.
 	EMTRecordsVariableLength                    // Generate a variable-length record when triggers are too close together.
 	EMTRecordsFullLengthIsolated                // Generate no records when triggers are too close together.
+	EMTRecordsOneFullLength                     // Generate a single record when triggers are too close together.
 )
 
 // t index of previous trigger
@@ -271,8 +272,13 @@ func edgeMultiShouldRecord(t, u, v FrameIndex, npreIn, nsampIn int32, mode EMTMo
 		return RecordSpec{-1, -1, -1}, false
 	}
 	if mode == EMTRecordsVariableLength {
-		// always make a record, but dont overlap with neighboring triggers
+		// always make a record, but don't overlap with neighboring triggers
 		return RecordSpec{u, npre, npre + npost}, true
+	} else if mode == EMTRecordsOneFullLength {
+		// always make a record, but don't overlap with neighboring triggers
+		if u-t >= FrameIndex(nsampIn) {
+			return RecordSpec{u, npreIn, nsampIn}, true
+		}
 	} else if mode == EMTRecordsTwoFullLength {
 		// always make a record, overlap with neighboring records
 		return RecordSpec{u, npreIn, nsampIn}, true

--- a/global_config.go
+++ b/global_config.go
@@ -35,7 +35,7 @@ type BuildInfo struct {
 
 // Build is a global holding compile-time information about the build
 var Build = BuildInfo{
-	Version: "0.3.6pre2",
+	Version: "0.3.6",
 	Githash: "no git hash computed",
 	Date:    "no build date computed",
 }


### PR DESCRIPTION
Create a new mode for retrigger cases in `EdgeMultiTrigger`: this mode is like classic triggering, where the original triggered record is permitted, but the retrigger is ignored. This is needed for PAX-CERN data. See #366.