### PR TITLE
Error on unequal rates

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -2,6 +2,7 @@
 
 **0.3.6** May 6, 2025-
 * Make Abaco data be considered unsigned (issue 364).
+* Panic at a point where it's easier to explain why, if 2 abaco groups find unequal sample rates (issue 359).
 
 **0.3.5** April 22, 2025
 * Fix bug that was writing zeros for the external trigger (issue 362).


### PR DESCRIPTION
Dastard is not compatible with having 2 or more data sources and unequal data sampling rates. If someone like @danbek tries to do this ridiculous thing, create a clearer panic message at the relevant place. Fixes #359 