### PR TITLE
Fix data panics when triggered records exceed array bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A data acquisition program for NIST transition-edge sensor (TES) microcalorimete
 
 ### Golang 1.21 is required
 
-**Dastad requires Go version 1.21 or higher** (released August 2023) because [gonum-v1 v0.15](http://gonum.org/v1/gonum/mat) and other depdencies require it. Dastard is tested automatically on versions 1.21 and _stable_, [the most recent stable version](https://github.com/actions/go-versions/blob/main/versions-manifest.json) (as of August 21, 2024, that means Go version 1.23.0).
+**Dastard requires Go version 1.21 or higher** (released August 2023) because [gonum-v1 v0.15](http://gonum.org/v1/gonum/mat) and other depdencies require it. Dastard is tested automatically on versions 1.21 and _stable_, [the most recent stable version](https://github.com/actions/go-versions/blob/main/versions-manifest.json) (as of August 21, 2024, that means Go version 1.23.0).
 - If you need to run Go version 1.20: don't. There was a bug in a filesystem handling library that renders Go 1.20 incompatible with our TDM systems specifically. If you are _not_ using TDM and insist on Go 1.20, follow the instructions for Go 1.19.
 - If you need to run Go versions 1.17, 1.18, 1.19: [Dastard version 0.3.3](https://github.com/usnistgov/dastard/releases/tag/v0.3.3) is the last version compatible with them.
 - If you need to run Go version 1.16: [Dastard version 0.2.16](https://github.com/usnistgov/dastard/releases/tag/v0.2.16) is the last version compatible with it.

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 ## DASTARD Versions
 
+**0.3.5** October, 2024-
+* Fix crashes when rate is high and a packet is dropped (issue 360).
+
 **0.3.4** August 23, 2024
 * Update all package dependencies (issue 347).
 * Send which types of files are active in the report about writing data (issue 343).

--- a/global_config.go
+++ b/global_config.go
@@ -35,7 +35,7 @@ type BuildInfo struct {
 
 // Build is a global holding compile-time information about the build
 var Build = BuildInfo{
-	Version: "0.3.4",
+	Version: "0.3.5pre1",
 	Githash: "no git hash computed",
 	Date:    "no build date computed",
 }

--- a/global_config.go
+++ b/global_config.go
@@ -35,7 +35,7 @@ type BuildInfo struct {
 
 // Build is a global holding compile-time information about the build
 var Build = BuildInfo{
-	Version: "0.3.6pre1",
+	Version: "0.3.6pre2",
 	Githash: "no git hash computed",
 	Date:    "no build date computed",
 }

--- a/publish_data_test.go
+++ b/publish_data_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -20,6 +21,8 @@ func TestPublishData(t *testing.T) {
 	d := []RawType{10, 10, 10, 10, 15, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10}
 	rec := &DataRecord{data: d, presamples: 4, modelCoefs: make([]float64, 3)}
 	records := []*DataRecord{rec, rec, rec, nil}
+	// Any errors in the triggering calcultion produce nil values for a record; remove them
+	records = slices.DeleteFunc(records, func(r *DataRecord) bool { return r == nil })
 
 	if err := dp.PublishData(records); err != nil {
 		t.Fail()
@@ -34,7 +37,7 @@ func TestPublishData(t *testing.T) {
 		t.Fail()
 	}
 	if dp.numberWritten != 3 {
-		t.Errorf("expected PublishData to increment numberWritten with LJH22 enabled")
+		t.Errorf("expected PublishData numberWritten with LJH22 enabled, (want %d, found %d)", 3, dp.numberWritten)
 	}
 	if !dp.HasLJH22() {
 		t.Error("HasLJH22() false, want true")
@@ -89,7 +92,7 @@ func TestPublishData(t *testing.T) {
 		t.Error("wrong number of RecordsWritten, want 3, have", dp.LJH3.RecordsWritten)
 	}
 	if dp.numberWritten != 3 {
-		t.Errorf("expected PublishedData to increment numberWritten")
+		t.Errorf("expected PublishedData to increment numberWritten, (want %d, found %d)", 3, dp.numberWritten)
 	}
 	if !dp.HasLJH3() {
 		t.Error("HasLJH3() false, want true")
@@ -115,7 +118,7 @@ func TestPublishData(t *testing.T) {
 		t.Error("wrong number of RecordsWritten, want 3, have", dp.OFF.RecordsWritten())
 	}
 	if dp.numberWritten != 3 {
-		t.Errorf("expected PublishedData to increment numberWritten")
+		t.Errorf("expected PublishedData to increment numberWritten (want %d, found %d)", 3, dp.numberWritten)
 	}
 	if !dp.HasOFF() {
 		t.Error("HasOFF() false, want true")

--- a/publish_data_test.go
+++ b/publish_data_test.go
@@ -19,7 +19,7 @@ func TestPublishData(t *testing.T) {
 	dp := DataPublisher{}
 	d := []RawType{10, 10, 10, 10, 15, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10}
 	rec := &DataRecord{data: d, presamples: 4, modelCoefs: make([]float64, 3)}
-	records := []*DataRecord{rec, rec, rec}
+	records := []*DataRecord{rec, rec, rec, nil}
 
 	if err := dp.PublishData(records); err != nil {
 		t.Fail()

--- a/rpc_server_test.go
+++ b/rpc_server_test.go
@@ -128,7 +128,7 @@ func TestServer(t *testing.T) {
 	sizes := SizeObject{Nsamp: 800, Npre: 200}
 	err = client.Call("SourceControl.ConfigurePulseLengths", &sizes, &okay)
 	if err != nil {
-		t.Logf(err.Error())
+		t.Log(err.Error())
 		t.Errorf("Error calling SourceControl.ConfigurePulseLengths(%v)", sizes)
 	}
 	if !okay {
@@ -138,7 +138,7 @@ func TestServer(t *testing.T) {
 
 	err = client.Call("SourceControl.Stop", sourceName, &okay)
 	if err != nil {
-		t.Logf(err.Error())
+		t.Log(err.Error())
 		t.Errorf("Error calling SourceControl.Stop(%s)", sourceName)
 	}
 	if !okay {

--- a/simulated_data_test.go
+++ b/simulated_data_test.go
@@ -1,7 +1,6 @@
 package dastard
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -274,7 +273,7 @@ func TestErroringSource(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		// 	// start the source, wait for it to end due to error, repeat
 		if err := Start(ds, nil, 256, 1024); err != nil {
-			t.Fatalf(fmt.Sprintf("Could not start ErroringSource: i=%v, err=%v", i, err))
+			t.Fatalf("Could not start ErroringSource: i=%v, err=%v", i, err)
 		}
 		es.RunDoneWait()
 		if ds.Running() {

--- a/triggering.go
+++ b/triggering.go
@@ -48,8 +48,9 @@ func (dsp *DataStreamProcessor) triggerAtSpecificSamples(i int, NPresamples int,
 	data := make([]RawType, NSamples)
 	stream := dsp.stream
 	if i < NPresamples {
-		fmt.Printf("We are about to panic, with i=%d, NPre=%d, NSamp=%d\n",
+		fmt.Printf("We would panic, except for returning nil, with i=%d, NPre=%d, NSamp=%d\n",
 			i, NPresamples, NSamples)
+		return nil
 	}
 	copy(data, stream.rawData[i-NPresamples:i+NSamples-NPresamples])
 	tf := stream.firstFrameIndex + FrameIndex(i)

--- a/triggering.go
+++ b/triggering.go
@@ -3,6 +3,7 @@ package dastard
 import (
 	"fmt"
 	"math"
+	"slices"
 	"sort"
 	"time"
 )
@@ -265,6 +266,9 @@ func (dsp *DataStreamProcessor) TriggerData() (records []*DataRecord) {
 		// pulses. We have found little need for this approach and leave this comment as a
 		// placeholder in case we ever want to add it.
 	}
+
+	// Any errors in the triggering calculation produce nil values for a record; remove them now.
+	records = slices.DeleteFunc(records, func(r *DataRecord) bool { return r == nil })
 
 	// Step 2: store the last trigger for the next invocation of TriggerData
 	if len(records) > 0 {

--- a/triggering.go
+++ b/triggering.go
@@ -1,6 +1,7 @@
 package dastard
 
 import (
+	"fmt"
 	"math"
 	"sort"
 	"time"
@@ -45,6 +46,10 @@ func (dsp *DataStreamProcessor) triggerAtSpecificSamples(i int, NPresamples int,
 
 	data := make([]RawType, NSamples)
 	stream := dsp.stream
+	if i < NPresamples {
+		fmt.Printf("We are about to panic, with i=%d, NPre=%d, NSamp=%d\n",
+			i, NPresamples, NSamples)
+	}
 	copy(data, stream.rawData[i-NPresamples:i+NSamples-NPresamples])
 	tf := stream.firstFrameIndex + FrameIndex(i)
 	tt := stream.TimeOf(i)


### PR DESCRIPTION
Fixes #360 or works around it. I'm not 100% sure. But we needed this change to operate successfully at BESSY. I'm adding it to the main line of code now.