### PR TITLE
Fix phi0 physical-raw conversion

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,8 @@
 ## DASTARD Versions
 
+**0.3.8** September 2, 2025-
+* Fix incorrect scaling of raw data to physical (phi0) units for µMUX source `AbacoSource` (issue 374).
+
 **0.3.7** August 5, 2025
 * Reorganize the sub-modules to live in "internal" (so their API isn't exposed outside Dastard).
 * Synchronize disk writes occasionally, and in parallel across multiple channels (issues 353, 354).

--- a/abaco.go
+++ b/abaco.go
@@ -728,6 +728,23 @@ func (as *AbacoSource) Delete() {
 	as.closeDevices()
 }
 
+// VoltsPerArb returns a per-channel value scaling raw into volts.
+// For Abaco, the default is 1 Phi0 per 4096 arb units
+func (as *AbacoSource) VoltsPerArb() []float32 {
+	if as.voltsPerArb == nil || len(as.voltsPerArb) != as.nchan {
+		as.voltsPerArb = make([]float32, as.nchan)
+		vpa := float32(1.0 / 65536.0) // default if not rescaling raw data
+		if (as.unwrapOpts.RescaleRaw){
+			vpa = float32(1. / (65536 >> abacoBitsToDrop))
+		}
+		for i := 0; i < as.nchan; i++ {
+			as.voltsPerArb[i] = vpa
+		}
+	}
+	return as.voltsPerArb
+}
+
+
 // AbacoSourceConfig holds the arguments needed to call AbacoSource.Configure by RPC.
 type AbacoSourceConfig struct {
 	ActiveCards    []int

--- a/abaco_test.go
+++ b/abaco_test.go
@@ -82,7 +82,6 @@ func TestAbacoRing(t *testing.T) {
 	if _, err := NewAbacoRing(99999); err == nil {
 		t.Errorf("NewAbacoRing(99999) succeeded, want failure")
 	}
-	rand.Seed(time.Now().UnixNano())
 	cardnum := -rand.Intn(99998) - 1 // Rand # between -1 and -99999
 	dev, err := NewAbacoRing(cardnum)
 	if err != nil {
@@ -192,7 +191,6 @@ func TestAbacoSource(t *testing.T) {
 		t.Fatalf("NewAbacoSource() fails: %s", err)
 	}
 
-	rand.Seed(time.Now().UnixNano())
 	cardnum := -rand.Intn(99998) - 1 // Rand # between -1 and -99999
 
 	dev, err := NewAbacoRing(cardnum)

--- a/edge_multi_trigger.go
+++ b/edge_multi_trigger.go
@@ -274,18 +274,19 @@ func edgeMultiShouldRecord(t, u, v FrameIndex, npreIn, nsampIn int32, mode EMTMo
 		// this will eventually lead to u == t as more triggers are inspected
 		return RecordSpec{-1, -1, -1}, false
 	}
-	if mode == EMTRecordsVariableLength {
+	switch mode {
+	case EMTRecordsVariableLength:
 		// always make a record, but don't overlap with neighboring triggers
 		return RecordSpec{u, npre, npre + npost}, true
-	} else if mode == EMTRecordsOneFullLength {
+	case EMTRecordsOneFullLength:
 		// always make a record, but don't overlap with neighboring triggers
 		if u-t >= FrameIndex(nsampIn) {
 			return RecordSpec{u, npreIn, nsampIn}, true
 		}
-	} else if mode == EMTRecordsTwoFullLength {
+	case EMTRecordsTwoFullLength:
 		// always make a record, overlap with neighboring records
 		return RecordSpec{u, npreIn, nsampIn}, true
-	} else if mode == EMTRecordsFullLengthIsolated {
+	case EMTRecordsFullLengthIsolated:
 		if npre >= npreIn && npre+npost >= nsampIn {
 			return RecordSpec{u, npreIn, nsampIn}, true
 		}

--- a/global_config.go
+++ b/global_config.go
@@ -40,7 +40,7 @@ type BuildInfo struct {
 
 // Build is a global holding compile-time information about the build
 var Build = BuildInfo{
-	Version: "0.3.7",
+	Version: "0.3.8pre1",
 	Githash: "no git hash computed",
 	Gitdate: "no git commit date entered",
 	Date:    "no build date computed",


### PR DESCRIPTION
Don't assume 1 volt = 65536 arbs, but use the `abacoBitsToDrop` value to get the correct scaling (currently, 1 phi0 = 4096 arbs because `abacoBitsToDrop=4`. Fixes #374.