### PR TITLE
Undo compulsory file sync when flushing

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -2,6 +2,7 @@
 
 **0.3.8** September 2, 2025-
 * Fix incorrect scaling of raw data to physical (phi0) units for µMUX source `AbacoSource` (issue 374).
+* Make the file-synchronizing be optional to avert HDD problem (issue 376).
 
 **0.3.7** August 5, 2025
 * Reorganize the sub-modules to live in "internal" (so their API isn't exposed outside Dastard).

--- a/abaco.go
+++ b/abaco.go
@@ -734,7 +734,7 @@ func (as *AbacoSource) VoltsPerArb() []float32 {
 	if as.voltsPerArb == nil || len(as.voltsPerArb) != as.nchan {
 		as.voltsPerArb = make([]float32, as.nchan)
 		vpa := float32(1.0 / 65536.0) // default if not rescaling raw data
-		if (as.unwrapOpts.RescaleRaw){
+		if as.unwrapOpts.RescaleRaw {
 			vpa = float32(1. / (65536 >> abacoBitsToDrop))
 		}
 		for i := 0; i < as.nchan; i++ {
@@ -743,7 +743,6 @@ func (as *AbacoSource) VoltsPerArb() []float32 {
 	}
 	return as.voltsPerArb
 }
-
 
 // AbacoSourceConfig holds the arguments needed to call AbacoSource.Configure by RPC.
 type AbacoSourceConfig struct {

--- a/data_source.go
+++ b/data_source.go
@@ -762,7 +762,7 @@ func (ds *AnySource) writeControlStart(config *WriteControlConfig) error {
 				timebase, DastardStartTime, nrows, ncols, ds.nchan, ds.subframeDivisions,
 				rowNum, colNum, ds.subframeOffsets[i], filename,
 				ds.name, ds.chanNames[i], ds.chanNumbers[i], pixel)
-			dsp.DataPublisher.LJH22.SyncFilesWithFlush(config.SyncWithFlush)
+			dsp.DataPublisher.LJH22.SetFlushAlsoSyncs(config.FlushAlsoSyncs)
 		}
 		if config.WriteOFF && dsp.HasProjectors() {
 			filename := fmt.Sprintf(filenamePattern, dsp.Name, "off")
@@ -771,14 +771,14 @@ func (ds *AnySource) writeControlStart(config *WriteControlConfig) error {
 				rowNum, colNum, ds.subframeOffsets[i], filename,
 				ds.name, ds.chanNames[i], ds.chanNumbers[i], dsp.projectors, dsp.basis,
 				dsp.modelDescription, pixel)
-			dsp.DataPublisher.OFF.SyncFilesWithFlush(config.SyncWithFlush)
+			dsp.DataPublisher.OFF.SetFlushAlsoSyncs(config.FlushAlsoSyncs)
 			channelsWithOff++
 		}
 		if config.WriteLJH3 {
 			filename := fmt.Sprintf(filenamePattern, dsp.Name, "ljh3")
 			dsp.DataPublisher.SetLJH3(i, timebase, nrows, ncols, ds.subframeDivisions,
 				ds.subframeOffsets[i], filename)
-			dsp.DataPublisher.LJH3.SyncFilesWithFlush(config.SyncWithFlush)
+			dsp.DataPublisher.LJH3.SetFlushAlsoSyncs(config.FlushAlsoSyncs)
 		}
 	}
 	return ds.writingState.Start(filenamePattern, path, config)

--- a/data_source.go
+++ b/data_source.go
@@ -762,6 +762,7 @@ func (ds *AnySource) writeControlStart(config *WriteControlConfig) error {
 				timebase, DastardStartTime, nrows, ncols, ds.nchan, ds.subframeDivisions,
 				rowNum, colNum, ds.subframeOffsets[i], filename,
 				ds.name, ds.chanNames[i], ds.chanNumbers[i], pixel)
+			dsp.DataPublisher.LJH22.SyncFilesWithFlush(config.SyncWithFlush)
 		}
 		if config.WriteOFF && dsp.HasProjectors() {
 			filename := fmt.Sprintf(filenamePattern, dsp.Name, "off")
@@ -770,12 +771,14 @@ func (ds *AnySource) writeControlStart(config *WriteControlConfig) error {
 				rowNum, colNum, ds.subframeOffsets[i], filename,
 				ds.name, ds.chanNames[i], ds.chanNumbers[i], dsp.projectors, dsp.basis,
 				dsp.modelDescription, pixel)
+			dsp.DataPublisher.OFF.SyncFilesWithFlush(config.SyncWithFlush)
 			channelsWithOff++
 		}
 		if config.WriteLJH3 {
 			filename := fmt.Sprintf(filenamePattern, dsp.Name, "ljh3")
 			dsp.DataPublisher.SetLJH3(i, timebase, nrows, ncols, ds.subframeDivisions,
 				ds.subframeOffsets[i], filename)
+			dsp.DataPublisher.LJH3.SyncFilesWithFlush(config.SyncWithFlush)
 		}
 	}
 	return ds.writingState.Start(filenamePattern, path, config)

--- a/global_config.go
+++ b/global_config.go
@@ -40,7 +40,7 @@ type BuildInfo struct {
 
 // Build is a global holding compile-time information about the build
 var Build = BuildInfo{
-	Version: "0.3.8pre1",
+	Version: "0.3.8pre2",
 	Githash: "no git hash computed",
 	Gitdate: "no git commit date entered",
 	Date:    "no build date computed",

--- a/internal/ljh/ljh.go
+++ b/internal/ljh/ljh.go
@@ -145,8 +145,8 @@ func extractFloat(line, pattern string, f *float64) bool {
 	return n >= 1 && err != nil
 }
 
-// SyncFilesWithFlush sets whether to call `Sync` with every `Flush` to the output file.
-func (w *Writer) SyncFilesWithFlush(sync bool) {
+// SetFlushAlsoSyncs sets whether to call `Sync` with every `Flush` to the output file.
+func (w *Writer) SetFlushAlsoSyncs(sync bool) {
 	w.syncwithflush = sync
 }
 
@@ -366,8 +366,8 @@ func (w Writer3) Close() {
 	w.file.Close()
 }
 
-// SyncFilesWithFlush sets whether to call `Sync` with every `Flush` to the output file.
-func (w *Writer3) SyncFilesWithFlush(sync bool) {
+// SetFlushAlsoSyncs sets whether to call `Sync` with every `Flush` to the output file.
+func (w *Writer3) SetFlushAlsoSyncs(sync bool) {
 	w.syncwithflush = sync
 }
 

--- a/internal/ljh/ljh.go
+++ b/internal/ljh/ljh.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"time"
@@ -223,9 +222,6 @@ func (w Writer) Flush() {
 		w.writer.Flush()
 		if w.syncwithflush {
 			w.file.Sync()
-			fmt.Println("Sync called")
-			fmt.Println()
-			log.Println("Snyc called")
 		}
 	}
 }

--- a/internal/ljh/ljh.go
+++ b/internal/ljh/ljh.go
@@ -145,7 +145,7 @@ func extractFloat(line, pattern string, f *float64) bool {
 }
 
 // CreateFile creates a file with filename .FileName and assigns it to .file
-// you can't write records without doing this
+// you can't write records without doing this.
 func (w *Writer) CreateFile() error {
 	if w.file == nil {
 		file, err := os.Create(w.FileName)

--- a/internal/off/off.go
+++ b/internal/off/off.go
@@ -57,6 +57,7 @@ type Writer struct {
 	headerWritten  bool
 	file           *os.File
 	writer         *asyncbufio.Writer
+	syncwithflush  bool
 }
 
 // NewWriter creates a new OFF writer. No file is created until the first call to WriteRecord
@@ -207,7 +208,9 @@ func (w *Writer) WriteRecord(recordSamples int32, recordPreSamples int32, framec
 func (w Writer) Flush() {
 	if w.writer != nil {
 		w.writer.Flush()
-		w.file.Sync()
+		if  w.syncwithflush {
+			w.file.Sync()
+		}
 	}
 }
 
@@ -219,8 +222,13 @@ func (w Writer) Close() {
 	w.file.Close()
 }
 
+// SyncFilesWithFlush sets whether to call `Sync` with every `Flush` to the output file.
+func (w *Writer) SyncFilesWithFlush(sync bool) {
+	w.syncwithflush = sync
+}
+
 // CreateFile creates a file at w.FileName
-// must be called before WriteHeader or WriteRecord
+// must be called before WriteHeader or WriteRecord.
 func (w *Writer) CreateFile() error {
 	if w.file == nil {
 		file, err := os.Create(w.fileName)

--- a/internal/off/off.go
+++ b/internal/off/off.go
@@ -222,8 +222,8 @@ func (w Writer) Close() {
 	w.file.Close()
 }
 
-// SyncFilesWithFlush sets whether to call `Sync` with every `Flush` to the output file.
-func (w *Writer) SyncFilesWithFlush(sync bool) {
+// SetFlushAlsoSyncs sets whether to call `Sync` with every `Flush` to the output file.
+func (w *Writer) SetFlushAlsoSyncs(sync bool) {
 	w.syncwithflush = sync
 }
 

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -437,7 +437,7 @@ type WriteControlConfig struct {
 	WriteLJH22      bool   // turn on one or more file formats
 	WriteOFF        bool
 	WriteLJH3       bool
-	SyncWithFlush   bool
+	FlushAlsoSyncs   bool
 	MapInternalOnly *Map // for dastard internal use only, used to pass map info to DataStreamProcessors
 }
 

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -437,6 +437,7 @@ type WriteControlConfig struct {
 	WriteLJH22      bool   // turn on one or more file formats
 	WriteOFF        bool
 	WriteLJH3       bool
+	SyncWithFlush   bool
 	MapInternalOnly *Map // for dastard internal use only, used to pass map info to DataStreamProcessors
 }
 

--- a/writing_state.go
+++ b/writing_state.go
@@ -17,6 +17,7 @@ type WritingState struct {
 	WriteLJH22                        bool // which file formats are active
 	WriteOFF                          bool
 	WriteLJH3                         bool
+	SyncWithFlush                     bool
 	experimentStateFile               *os.File
 	ExperimentStateFilename           string
 	ExperimentStateLabel              string
@@ -60,6 +61,7 @@ func (ws *WritingState) ComputeState() *WritingState {
 	copyState.WriteLJH22 = ws.WriteLJH22
 	copyState.WriteLJH3 = ws.WriteLJH3
 	copyState.WriteOFF = ws.WriteOFF
+	copyState.SyncWithFlush = ws.SyncWithFlush
 	return &copyState
 }
 
@@ -73,6 +75,7 @@ func (ws *WritingState) Start(filenamePattern, path string, config *WriteControl
 	ws.WriteLJH22 = config.WriteLJH22
 	ws.WriteLJH3 = config.WriteLJH3
 	ws.WriteOFF = config.WriteOFF
+	ws.SyncWithFlush = config.SyncWithFlush
 	ws.FilenamePattern = filenamePattern
 	ws.ExperimentStateFilename = fmt.Sprintf(filenamePattern, "experiment_state", "txt")
 	ws.ExternalTriggerFilename = fmt.Sprintf(filenamePattern, "external_trigger", "bin")

--- a/writing_state.go
+++ b/writing_state.go
@@ -17,7 +17,7 @@ type WritingState struct {
 	WriteLJH22                        bool // which file formats are active
 	WriteOFF                          bool
 	WriteLJH3                         bool
-	SyncWithFlush                     bool
+	FlushAlsoSyncs                     bool
 	experimentStateFile               *os.File
 	ExperimentStateFilename           string
 	ExperimentStateLabel              string
@@ -61,7 +61,7 @@ func (ws *WritingState) ComputeState() *WritingState {
 	copyState.WriteLJH22 = ws.WriteLJH22
 	copyState.WriteLJH3 = ws.WriteLJH3
 	copyState.WriteOFF = ws.WriteOFF
-	copyState.SyncWithFlush = ws.SyncWithFlush
+	copyState.FlushAlsoSyncs = ws.FlushAlsoSyncs
 	return &copyState
 }
 
@@ -75,7 +75,7 @@ func (ws *WritingState) Start(filenamePattern, path string, config *WriteControl
 	ws.WriteLJH22 = config.WriteLJH22
 	ws.WriteLJH3 = config.WriteLJH3
 	ws.WriteOFF = config.WriteOFF
-	ws.SyncWithFlush = config.SyncWithFlush
+	ws.FlushAlsoSyncs = config.FlushAlsoSyncs
 	ws.FilenamePattern = filenamePattern
 	ws.ExperimentStateFilename = fmt.Sprintf(filenamePattern, "experiment_state", "txt")
 	ws.ExternalTriggerFilename = fmt.Sprintf(filenamePattern, "external_trigger", "bin")


### PR DESCRIPTION
The mandatory file `Sync()` with each flush is now optional. Experience suggests that we don't often want this, but NSLS-II seemed to need it. Fixes #376.

For now, sync-with-=flush is off by default. To use sync with flush, check your `~/.dastard/config.yaml` and modify this one value to be true:

```yaml
writing:
    ...
    flushalsosyncs: true
   ...
```