### PR TITLE
Send channel names before trigger info to clients

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,6 +4,7 @@
 * Remove relic internals/ringbuffers and ability of Abaco to use it as a data source (issue 382).
 * Modernize to use Go 1.22+ features like `for range n` loops (issue 384),
   with `go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -test  -fix ./...`
+* Broadcast channel names to clients before info that requires the name-numbering-index relationship (issue 388).
 
 **0.3.8** December 8, 2025
 * Fix incorrect scaling of raw data to physical (phi0) units for µMUX source `AbacoSource` (issue 374).

--- a/global_config.go
+++ b/global_config.go
@@ -40,7 +40,7 @@ type BuildInfo struct {
 
 // Build is a global holding compile-time information about the build
 var Build = BuildInfo{
-	Version: "0.3.9pre2",
+	Version: "0.3.9pre3",
 	Githash: "no git hash computed",
 	Gitdate: "no git commit date entered",
 	Date:    "no build date computed",

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -381,9 +381,9 @@ func (s *SourceControl) Start(sourceName *string, reply *bool) error {
 	s.status.Nchannels = s.ActiveSource.Nchan()
 	s.status.ChanGroups = s.ActiveSource.ChanGroups()
 	s.broadcastStatus()
+	s.broadcastChannelNames()
 	s.broadcastTriggerState()
 	s.broadcastGroupTriggerState()
-	s.broadcastChannelNames()
 	s.storeChannelGroups()
 	*reply = true
 	return nil


### PR DESCRIPTION
Clients need the channel name-number-index mapping to make sense of the trigger info messages, so send the one before the other. Fixes #388.